### PR TITLE
Exclude empty params from file upload

### DIFF
--- a/HubSpot.NET/Core/HubSpotBaseClient.cs
+++ b/HubSpot.NET/Core/HubSpotBaseClient.cs
@@ -109,9 +109,17 @@ namespace HubSpot.NET.Core
             IRestRequest request = ConfigureRequestAuthentication(path, method, null);
 
             request.AddFileBytes("file", data, filename);
-            
+
             foreach (KeyValuePair<string, string> kvp in parameters)
+            {
+                if (string.IsNullOrEmpty(kvp.Value))
+                {
+                    continue;
+                }
+                
                 request.AddParameter(kvp.Key, kvp.Value);
+            }
+               
 
             IRestResponse<T> response = _client.Execute<T>(request);
 


### PR DESCRIPTION
## Description
Excludes empty parameters from the file upload method. Only `folderId` or `folderPath` can be passed as a param. Passing an empty value with one of the keys causes the request to fail with a 500 error, so we exclude the empty param entirely from the payload.

## Purpose
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
