### PR TITLE
Add a method to fetch the hubspot hours mileage 

### DIFF
--- a/HubSpot.NET.Examples/Program.cs
+++ b/HubSpot.NET.Examples/Program.cs
@@ -68,7 +68,7 @@ namespace HubSpot.NET.Examples
                     {"make", "Ford"},
                     {"model", "150" + DateTime.Now.Hour + DateTime.Now.Minute},
                     {"name", $"2015 Ford 150"},
-                    {"hoursMileage", $"1000" }
+                    {"hoursmileage", $"1000" }
                 },
                 Associations = new List<CreateCustomObjectHubSpotModel.Association>()
                 {

--- a/HubSpot.NET.Examples/Program.cs
+++ b/HubSpot.NET.Examples/Program.cs
@@ -67,7 +67,8 @@ namespace HubSpot.NET.Examples
                     {"year1", 2014},
                     {"make", "Ford"},
                     {"model", "150" + DateTime.Now.Hour + DateTime.Now.Minute},
-                    {"name", $"2015 Ford 150"}
+                    {"name", $"2015 Ford 150"},
+                    {"hoursMileage", $"1000" }
                 },
                 Associations = new List<CreateCustomObjectHubSpotModel.Association>()
                 {
@@ -107,6 +108,7 @@ namespace HubSpot.NET.Examples
             // 9909067546 => deal id
             var newEquipmentId = api.CustomObjects.CreateWithDefaultAssociationToObject(newEquipment, "0-3", "9909067546");
             
+            var getEquipment = api.CustomObjects.GetObject<GetHubspotHoursMileageModel>(id, newEquipmentId);
             
             var result3 = api.CustomObjects.GetAssociationsToCustomObject
                 <CustomObjectAssociationModel>("2-4390924", "3254092177",

--- a/HubSpot.NET.Examples/Program.cs
+++ b/HubSpot.NET.Examples/Program.cs
@@ -108,7 +108,7 @@ namespace HubSpot.NET.Examples
             // 9909067546 => deal id
             var newEquipmentId = api.CustomObjects.CreateWithDefaultAssociationToObject(newEquipment, "0-3", "9909067546");
             
-            var getEquipment = api.CustomObjects.GetObject<GetHubspotHoursMileageModel>(id, newEquipmentId);
+            var getEquipment = api.CustomObjects.GetEquipmentHourMileage<GetHubspotHoursMileageModel>(id, newEquipmentId);
             
             var result3 = api.CustomObjects.GetAssociationsToCustomObject
                 <CustomObjectAssociationModel>("2-4390924", "3254092177",

--- a/HubSpot.NET.Examples/Program.cs
+++ b/HubSpot.NET.Examples/Program.cs
@@ -109,7 +109,10 @@ namespace HubSpot.NET.Examples
             var newEquipmentId = api.CustomObjects.CreateWithDefaultAssociationToObject(newEquipment, "0-3", "9909067546");
             
             var getEquipment = api.CustomObjects.GetEquipmentDataById<GetHubspotEquipmentObjectModel>(id, newEquipmentId);
-            
+
+
+            var getEquipmentHours = api.CustomObjects.GetEquipmentDataById<GetHubspotEquipmentObjectModel>(id, newEquipmentId, "hoursmileage");
+
             var result3 = api.CustomObjects.GetAssociationsToCustomObject
                 <CustomObjectAssociationModel>("2-4390924", "3254092177",
                 "0-1", CancellationToken.None);

--- a/HubSpot.NET.Examples/Program.cs
+++ b/HubSpot.NET.Examples/Program.cs
@@ -108,7 +108,7 @@ namespace HubSpot.NET.Examples
             // 9909067546 => deal id
             var newEquipmentId = api.CustomObjects.CreateWithDefaultAssociationToObject(newEquipment, "0-3", "9909067546");
             
-            var getEquipment = api.CustomObjects.GetEquipmentHourMileage<GetHubspotHoursMileageModel>(id, newEquipmentId);
+            var getEquipment = api.CustomObjects.GetEquipmentDataById<GetHubspotEquipmentObjectModel>(id, newEquipmentId);
             
             var result3 = api.CustomObjects.GetAssociationsToCustomObject
                 <CustomObjectAssociationModel>("2-4390924", "3254092177",

--- a/HubSpot.NET/Api/CustomObject/EquipmentObjectList.cs
+++ b/HubSpot.NET/Api/CustomObject/EquipmentObjectList.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace HubSpot.NET.Api.CustomObject
+{
+    public static class EquipmentObjectList
+    {
+        public static string GetEquipmentPropsList()
+        {
+            var equipmentPropsList =  new List<string>
+            {
+                "additional_information",
+                "backoffice_id",
+                "bb_eng_legacy_equipmentcategory_slug",
+                "category",
+                "city",
+                "commission_percent",
+                "date_of_first_qualified_lead",
+                "equipment_title",
+                "fleet_identifier",
+                "hs_all_accessible_team_ids",
+                "hs_all_assigned_business_unit_ids",
+                "hs_all_owner_ids",
+                "hs_all_team_ids",
+                "hs_created_by_user_id",
+                "hs_createdate",
+                "hs_lastmodifieddate",
+                "hs_merged_object_ids",
+                "hs_object_id",
+                "hs_object_source",
+                "hs_object_source_id",
+                "hs_object_source_user_id",
+                "hs_pinned_engagement_id",
+                "hs_read_only",
+                "hs_unique_creation_key",
+                "hs_updated_by_user_id",
+                "hs_user_ids_of_all_notification_followers",
+                "hs_user_ids_of_all_notification_unfollowers",
+                "hs_user_ids_of_all_owners",
+                "hs_was_imported",
+                "hubspot_owner_assigneddate",
+                "hubspot_owner_id",
+                "hubspot_team_id",
+                "item_number",
+                "karintest",
+                "line_item_id",
+                "listing_to_lead_time",
+                "location",
+                "location_combined",
+                "machine_posted_datestamp",
+                "make",
+                "make__other",
+                "new_associated_deal",
+                "photo",
+                "poc_email",
+                "product_id",
+                "qualified_to_buy_datestamp",
+                "seller_company_id",
+                "seller_company_name",
+                "seller_contact_id",
+                "seller_deal_id",
+                "state",
+                "submission_idempotent_id",
+                "time_between_posted_and_first_buyer",
+                "warranty_eligible",
+                "year",
+                "year1",
+                "zip_code",
+                "name",
+                "model",
+                "vin",
+                "hoursmileage"
+            };
+            return string.Join(",", equipmentPropsList);
+        }
+    }
+}

--- a/HubSpot.NET/Api/CustomObject/EquipmentObjectModel.cs
+++ b/HubSpot.NET/Api/CustomObject/EquipmentObjectModel.cs
@@ -36,18 +36,6 @@ public class GetHubspotEquipmentObjectModel : IHubSpotModel
     [DataMember(Name = "fleet_identifier")]
     public string? FleetIdentifier { get; set; }
 
-    /*[DataMember(Name = "hs_all_accessible_team_ids")]
-    public List<int>? HsAllAccessibleTeamIds { get; set; }
-
-    [DataMember(Name = "hs_all_assigned_business_unit_ids")]
-    public List<int>? HsAllAssignedBusinessUnitIds { get; set; }
-
-    [DataMember(Name = "hs_all_owner_ids")]
-    public List<int>? HsAllOwnerIds { get; set; }
-
-    [DataMember(Name = "hs_all_team_ids")]
-    public List<int>? HsAllTeamIds { get; set; }*/
-
     [DataMember(Name = "hs_created_by_user_id")]
     public string? HsCreatedByUserId { get; set; }
 
@@ -56,9 +44,6 @@ public class GetHubspotEquipmentObjectModel : IHubSpotModel
 
     [DataMember(Name = "hs_lastmodifieddate")]
     public DateTime? HsLastModifiedDate { get; set; }
-
-   /* [DataMember(Name = "hs_merged_object_ids")]
-    public List<int>? HsMergedObjectIds { get; set; }*/
 
     [DataMember(Name = "hs_object_id")]
     public string? HsObjectId { get; set; }
@@ -83,16 +68,7 @@ public class GetHubspotEquipmentObjectModel : IHubSpotModel
 
     [DataMember(Name = "hs_updated_by_user_id")]
     public string? HsUpdatedByUserId { get; set; }
-
-    /*[DataMember(Name = "hs_user_ids_of_all_notification_followers")]
-    public List<int>? HsUserIdsOfAllNotificationFollowers { get; set; }
-
-    [DataMember(Name = "hs_user_ids_of_all_notification_unfollowers")]
-    public List<int>? HsUserIdsOfAllNotificationUnfollowers { get; set; }
-
-    [DataMember(Name = "hs_user_ids_of_all_owners")]
-    public List<int>? HsUserIdsOfAllOwners { get; set; }
-    */
+    
     [DataMember(Name = "hs_was_imported")]
     public bool? HsWasImported { get; set; }
 

--- a/HubSpot.NET/Api/CustomObject/EquipmentObjectModel.cs
+++ b/HubSpot.NET/Api/CustomObject/EquipmentObjectModel.cs
@@ -1,0 +1,205 @@
+﻿using HubSpot.NET.Core.Interfaces;
+using System.Collections.Generic;
+using System;
+using System.Runtime.Serialization;
+using System.Xml.Linq;
+
+namespace HubSpot.NET.Api.CustomObject;
+public class GetHubspotEquipmentObjectModel : IHubSpotModel
+{
+#nullable enable
+
+    [DataMember(Name = "additional_information")]
+    public string? AdditionalInformation { get; set; }
+
+    [DataMember(Name = "backoffice_id")]
+    public string? BackofficeId { get; set; }
+
+    [DataMember(Name = "bb_eng_legacy_equipmentcategory_slug")]
+    public string? BbEngLegacyEquipmentCategorySlug { get; set; }
+
+    [DataMember(Name = "category")]
+    public string? Category { get; set; }
+
+    [DataMember(Name = "city")]
+    public string? City { get; set; }
+
+    [DataMember(Name = "commission_percent")]
+    public double? CommissionPercent { get; set; }
+
+    [DataMember(Name = "date_of_first_qualified_lead")]
+    public DateTime? DateOfFirstQualifiedLead { get; set; }
+
+    [DataMember(Name = "equipment_title")]
+    public string? EquipmentTitle { get; set; }
+
+    [DataMember(Name = "fleet_identifier")]
+    public string? FleetIdentifier { get; set; }
+
+    /*[DataMember(Name = "hs_all_accessible_team_ids")]
+    public List<int>? HsAllAccessibleTeamIds { get; set; }
+
+    [DataMember(Name = "hs_all_assigned_business_unit_ids")]
+    public List<int>? HsAllAssignedBusinessUnitIds { get; set; }
+
+    [DataMember(Name = "hs_all_owner_ids")]
+    public List<int>? HsAllOwnerIds { get; set; }
+
+    [DataMember(Name = "hs_all_team_ids")]
+    public List<int>? HsAllTeamIds { get; set; }*/
+
+    [DataMember(Name = "hs_created_by_user_id")]
+    public string? HsCreatedByUserId { get; set; }
+
+    [DataMember(Name = "hs_createdate")]
+    public DateTime? HsCreateDate { get; set; }
+
+    [DataMember(Name = "hs_lastmodifieddate")]
+    public DateTime? HsLastModifiedDate { get; set; }
+
+   /* [DataMember(Name = "hs_merged_object_ids")]
+    public List<int>? HsMergedObjectIds { get; set; }*/
+
+    [DataMember(Name = "hs_object_id")]
+    public string? HsObjectId { get; set; }
+
+    [DataMember(Name = "hs_object_source")]
+    public string? HsObjectSource { get; set; }
+
+    [DataMember(Name = "hs_object_source_id")]
+    public string? HsObjectSourceId { get; set; }
+
+    [DataMember(Name = "hs_object_source_user_id")]
+    public string? HsObjectSourceUserId { get; set; }
+
+    [DataMember(Name = "hs_pinned_engagement_id")]
+    public string? HsPinnedEngagementId { get; set; }
+
+    [DataMember(Name = "hs_read_only")]
+    public bool? HsReadOnly { get; set; }
+
+    [DataMember(Name = "hs_unique_creation_key")]
+    public string? HsUniqueCreationKey { get; set; }
+
+    [DataMember(Name = "hs_updated_by_user_id")]
+    public string? HsUpdatedByUserId { get; set; }
+
+    /*[DataMember(Name = "hs_user_ids_of_all_notification_followers")]
+    public List<int>? HsUserIdsOfAllNotificationFollowers { get; set; }
+
+    [DataMember(Name = "hs_user_ids_of_all_notification_unfollowers")]
+    public List<int>? HsUserIdsOfAllNotificationUnfollowers { get; set; }
+
+    [DataMember(Name = "hs_user_ids_of_all_owners")]
+    public List<int>? HsUserIdsOfAllOwners { get; set; }
+    */
+    [DataMember(Name = "hs_was_imported")]
+    public bool? HsWasImported { get; set; }
+
+    [DataMember(Name = "hubspot_owner_assigneddate")]
+    public DateTime? HubspotOwnerAssignedDate { get; set; }
+
+    [DataMember(Name = "hubspot_owner_id")]
+    public string? HubspotOwnerId { get; set; }
+
+    [DataMember(Name = "hubspot_team_id")]
+    public string? HubspotTeamId { get; set; }
+
+    [DataMember(Name = "item_number")]
+    public string? ItemNumber { get; set; }
+
+    [DataMember(Name = "karintest")]
+    public string? KarinTest { get; set; }
+
+    [DataMember(Name = "line_item_id")]
+    public string? LineItemId { get; set; }
+
+    [DataMember(Name = "listing_to_lead_time")]
+    public string? ListingToLeadTime { get; set; }
+
+    [DataMember(Name = "location")]
+    public string? Location { get; set; }
+
+    [DataMember(Name = "location_combined")]
+    public string? LocationCombined { get; set; }
+
+    [DataMember(Name = "machine_posted_datestamp")]
+    public DateTime? MachinePostedDatestamp { get; set; }
+
+    [DataMember(Name = "make")]
+    public string? Make { get; set; }
+
+    [DataMember(Name = "make__other")]
+    public string? MakeOther { get; set; }
+
+    [DataMember(Name = "new_associated_deal")]
+    public bool? NewAssociatedDeal { get; set; }
+
+    [DataMember(Name = "photo")]
+    public string? Photo { get; set; }
+
+    [DataMember(Name = "poc_email")]
+    public string? PocEmail { get; set; }
+
+    [DataMember(Name = "product_id")]
+    public string? ProductId { get; set; }
+
+    [DataMember(Name = "qualified_to_buy_datestamp")]
+    public DateTime? QualifiedToBuyDatestamp { get; set; }
+
+    [DataMember(Name = "seller_company_id")]
+    public string? SellerCompanyId { get; set; }
+
+    [DataMember(Name = "seller_company_name")]
+    public string? SellerCompanyName { get; set; }
+
+    [DataMember(Name = "seller_contact_id")]
+    public string? SellerContactId { get; set; }
+
+    [DataMember(Name = "seller_deal_id")]
+    public string? SellerDealId { get; set; }
+
+    [DataMember(Name = "state")]
+    public string? State { get; set; }
+
+    [DataMember(Name = "submission_idempotent_id")]
+    public string? SubmissionIdempotentId { get; set; }
+
+    [DataMember(Name = "time_between_posted_and_first_buyer")]
+    public string? TimeBetweenPostedAndFirstBuyer { get; set; }
+
+    [DataMember(Name = "warranty_eligible")]
+    public bool? WarrantyEligible { get; set; }
+
+    [DataMember(Name = "year")]
+    public string? Year { get; set; }
+
+    [DataMember(Name = "year1")]
+    public string? Year1 { get; set; }
+
+    [DataMember(Name = "zip_code")]
+    public string? ZipCode { get; set; }
+
+    [DataMember(Name = "name")]
+    public string? Name { get; set; }
+
+    [DataMember(Name = "model")]
+    public string? Model { get; set; }
+
+    [DataMember(Name = "vin")]
+    public string? Vin { get; set; }
+
+    [DataMember(Name = "hoursmileage")]
+    public string? HoursMileage { get; set; }
+
+    public bool IsNameValue => false;
+    public void ToHubSpotDataEntity(ref dynamic dataEntity)
+    {
+    }
+
+    public void FromHubSpotDataEntity(dynamic hubspotData)
+    {
+    }
+
+    public string RouteBasePath => "crm/v3/objects";
+}

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -242,9 +242,13 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         return string.Empty;
     }
 
-    const string allEquipmentObjectProperties = "additional_information,backoffice_id,bb_eng_legacy_equipmentcategory_slug,category,city,commission_percent,date_of_first_qualified_lead,equipment_title,fleet_identifier,hs_all_accessible_team_ids,hs_all_assigned_business_unit_ids,hs_all_owner_ids,hs_all_team_ids,hs_created_by_user_id,hs_createdate,hs_lastmodifieddate,hs_merged_object_ids,hs_object_id,hs_object_source,hs_object_source_id,hs_object_source_user_id,hs_pinned_engagement_id,hs_read_only,hs_unique_creation_key,hs_updated_by_user_id,hs_user_ids_of_all_notification_followers,hs_user_ids_of_all_notification_unfollowers,hs_user_ids_of_all_owners,hs_was_imported,hubspot_owner_assigneddate,hubspot_owner_id,hubspot_team_id,item_number,karintest,line_item_id,listing_to_lead_time,location,location_combined,machine_posted_datestamp,make,make__other,new_associated_deal,photo,poc_email,product_id,qualified_to_buy_datestamp,seller_company_id,seller_company_name,seller_contact_id,seller_deal_id,state,submission_idempotent_id,time_between_posted_and_first_buyer,warranty_eligible,year,year1,zip_code,name,model,vin,hoursmileage";
-    public T GetEquipmentDataById<T>(string schemaId, string entityId, string properties=allEquipmentObjectProperties) where T : GetHubspotEquipmentObjectModel, new()
+    public T GetEquipmentDataById<T>(string schemaId, string entityId, string properties = "") where T : GetHubspotEquipmentObjectModel, new()
     {
+        if(properties == "")
+        {
+            properties = EquipmentObjectList.GetEquipmentPropsList();
+        }
+
         var path = $"{RouteBasePath}/{schemaId}/{entityId}";
 
         path = path.SetQueryParam("properties", properties); //properties is comma seperated value of properties to include

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -123,6 +123,25 @@ public class CustomObjectHubSpotModel : IHubSpotModel
 }
 
 
+public class GetHubspotHoursMileageModel : IHubSpotModel
+{
+    [DataMember(Name = "hoursMileage")]
+    public string HoursMileage { get; set; }
+
+
+
+    public bool IsNameValue => false;
+    public void ToHubSpotDataEntity(ref dynamic dataEntity)
+    {
+    }
+
+    public void FromHubSpotDataEntity(dynamic hubspotData)
+    {
+    }
+
+    public string RouteBasePath => "crm/v3/objects";
+}
+
 public class CustomObjectListAssociationsModel<T> : IHubSpotModel where T : CustomObjectAssociationModel, new()
 {
     [DataMember(Name = "results")]
@@ -241,5 +260,14 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         _client.Execute<UpdateCustomObjectHubSpotModel>(path, entity, Method.PATCH, convertToPropertiesSchema: false);
         
         return string.Empty;
+    }
+
+    public T GetObject<T>(string schemaId, string entityId) where T : GetHubspotHoursMileageModel, new()
+    {
+        var path = $"{RouteBasePath}/{schemaId}/{entityId}";
+
+    var res = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: false);
+
+        return res;
     }
 }

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -122,26 +122,6 @@ public class CustomObjectHubSpotModel : IHubSpotModel
     public string RouteBasePath => "crm/v3/objects";
 }
 
-
-public class GetHubspotHoursMileageModel : IHubSpotModel
-{
-    [DataMember(Name = "hoursmileage")]
-    public string HoursMileage { get; set; }
-
-
-
-    public bool IsNameValue => false;
-    public void ToHubSpotDataEntity(ref dynamic dataEntity)
-    {
-    }
-
-    public void FromHubSpotDataEntity(dynamic hubspotData)
-    {
-    }
-
-    public string RouteBasePath => "crm/v3/objects";
-}
-
 public class CustomObjectListAssociationsModel<T> : IHubSpotModel where T : CustomObjectAssociationModel, new()
 {
     [DataMember(Name = "results")]
@@ -262,11 +242,12 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         return string.Empty;
     }
 
-    public T GetEquipmentHourMileage<T>(string schemaId, string entityId) where T : GetHubspotHoursMileageModel, new()
+    const string allEquipmentObjectProperties = "additional_information,backoffice_id,bb_eng_legacy_equipmentcategory_slug,category,city,commission_percent,date_of_first_qualified_lead,equipment_title,fleet_identifier,hs_all_accessible_team_ids,hs_all_assigned_business_unit_ids,hs_all_owner_ids,hs_all_team_ids,hs_created_by_user_id,hs_createdate,hs_lastmodifieddate,hs_merged_object_ids,hs_object_id,hs_object_source,hs_object_source_id,hs_object_source_user_id,hs_pinned_engagement_id,hs_read_only,hs_unique_creation_key,hs_updated_by_user_id,hs_user_ids_of_all_notification_followers,hs_user_ids_of_all_notification_unfollowers,hs_user_ids_of_all_owners,hs_was_imported,hubspot_owner_assigneddate,hubspot_owner_id,hubspot_team_id,item_number,karintest,line_item_id,listing_to_lead_time,location,location_combined,machine_posted_datestamp,make,make__other,new_associated_deal,photo,poc_email,product_id,qualified_to_buy_datestamp,seller_company_id,seller_company_name,seller_contact_id,seller_deal_id,state,submission_idempotent_id,time_between_posted_and_first_buyer,warranty_eligible,year,year1,zip_code,name,model,vin,hoursmileage";
+    public T GetEquipmentDataById<T>(string schemaId, string entityId, string properties=allEquipmentObjectProperties) where T : GetHubspotEquipmentObjectModel, new()
     {
         var path = $"{RouteBasePath}/{schemaId}/{entityId}";
 
-        path = path.SetQueryParam("properties", "hoursmileage");
+        path = path.SetQueryParam("properties", properties); //properties is comma seperated value of properties to include
 
         var res = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: true);
 

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -125,7 +125,7 @@ public class CustomObjectHubSpotModel : IHubSpotModel
 
 public class GetHubspotHoursMileageModel : IHubSpotModel
 {
-    [DataMember(Name = "hoursMileage")]
+    [DataMember(Name = "hoursmileage")]
     public string HoursMileage { get; set; }
 
 
@@ -266,7 +266,9 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
     {
         var path = $"{RouteBasePath}/{schemaId}/{entityId}";
 
-    var res = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: false);
+        path = path.SetQueryParam("properties", "hoursmileage");
+
+        var res = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: true);
 
         return res;
     }

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -262,7 +262,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         return string.Empty;
     }
 
-    public T GetObject<T>(string schemaId, string entityId) where T : GetHubspotHoursMileageModel, new()
+    public T GetEquipmentHourMileage<T>(string schemaId, string entityId) where T : GetHubspotHoursMileageModel, new()
     {
         var path = $"{RouteBasePath}/{schemaId}/{entityId}";
 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -18,5 +18,6 @@ public interface IHubSpotCustomObjectApi
     string UpdateObject<T>(T entity)
         where T : UpdateCustomObjectHubSpotModel, new();
 
-    T GetEquipmentHourMileage<T>(string schemaId, string entityId) where T : GetHubspotHoursMileageModel, new();
+    const string allEquipmentObjectProperties = "additional_information,backoffice_id,bb_eng_legacy_equipmentcategory_slug,category,city,commission_percent,date_of_first_qualified_lead,equipment_title,fleet_identifier,hs_all_accessible_team_ids,hs_all_assigned_business_unit_ids,hs_all_owner_ids,hs_all_team_ids,hs_created_by_user_id,hs_createdate,hs_lastmodifieddate,hs_merged_object_ids,hs_object_id,hs_object_source,hs_object_source_id,hs_object_source_user_id,hs_pinned_engagement_id,hs_read_only,hs_unique_creation_key,hs_updated_by_user_id,hs_user_ids_of_all_notification_followers,hs_user_ids_of_all_notification_unfollowers,hs_user_ids_of_all_owners,hs_was_imported,hubspot_owner_assigneddate,hubspot_owner_id,hubspot_team_id,item_number,karintest,line_item_id,listing_to_lead_time,location,location_combined,machine_posted_datestamp,make,make__other,new_associated_deal,photo,poc_email,product_id,qualified_to_buy_datestamp,seller_company_id,seller_company_name,seller_contact_id,seller_deal_id,state,submission_idempotent_id,time_between_posted_and_first_buyer,warranty_eligible,year,year1,zip_code,name,model,vin,hoursmileage";
+    T GetEquipmentDataById<T>(string schemaId, string entityId, string properties=allEquipmentObjectProperties) where T : GetHubspotEquipmentObjectModel, new();
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -17,4 +17,6 @@ public interface IHubSpotCustomObjectApi
     
     string UpdateObject<T>(T entity)
         where T : UpdateCustomObjectHubSpotModel, new();
+
+    T GetObject<T>(string schemaId, string entityId) where T : GetHubspotHoursMileageModel, new();
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -18,5 +18,5 @@ public interface IHubSpotCustomObjectApi
     string UpdateObject<T>(T entity)
         where T : UpdateCustomObjectHubSpotModel, new();
 
-    T GetObject<T>(string schemaId, string entityId) where T : GetHubspotHoursMileageModel, new();
+    T GetEquipmentHourMileage<T>(string schemaId, string entityId) where T : GetHubspotHoursMileageModel, new();
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotCustomObjectApi.cs
@@ -17,7 +17,5 @@ public interface IHubSpotCustomObjectApi
     
     string UpdateObject<T>(T entity)
         where T : UpdateCustomObjectHubSpotModel, new();
-
-    const string allEquipmentObjectProperties = "additional_information,backoffice_id,bb_eng_legacy_equipmentcategory_slug,category,city,commission_percent,date_of_first_qualified_lead,equipment_title,fleet_identifier,hs_all_accessible_team_ids,hs_all_assigned_business_unit_ids,hs_all_owner_ids,hs_all_team_ids,hs_created_by_user_id,hs_createdate,hs_lastmodifieddate,hs_merged_object_ids,hs_object_id,hs_object_source,hs_object_source_id,hs_object_source_user_id,hs_pinned_engagement_id,hs_read_only,hs_unique_creation_key,hs_updated_by_user_id,hs_user_ids_of_all_notification_followers,hs_user_ids_of_all_notification_unfollowers,hs_user_ids_of_all_owners,hs_was_imported,hubspot_owner_assigneddate,hubspot_owner_id,hubspot_team_id,item_number,karintest,line_item_id,listing_to_lead_time,location,location_combined,machine_posted_datestamp,make,make__other,new_associated_deal,photo,poc_email,product_id,qualified_to_buy_datestamp,seller_company_id,seller_company_name,seller_contact_id,seller_deal_id,state,submission_idempotent_id,time_between_posted_and_first_buyer,warranty_eligible,year,year1,zip_code,name,model,vin,hoursmileage";
-    T GetEquipmentDataById<T>(string schemaId, string entityId, string properties=allEquipmentObjectProperties) where T : GetHubspotEquipmentObjectModel, new();
+    T GetEquipmentDataById<T>(string schemaId, string entityId, string properties="") where T : GetHubspotEquipmentObjectModel, new();
 }


### PR DESCRIPTION
## Description
Add a method to fetch the hubspot hours mileage for an equipment custom object

##How to test
 put a breakpoint on this line
var getEquipment = api.CustomObjects.GetEquipmentHourMileage<GetHubspotHoursMileageModel>(id, newEquipmentId);
and run the Hubspot.Net.Staging . See the value of getEquipment.

## Purpose
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
