### PR TITLE
Change type of NewAssociatedDeal to match HubSpot field

### DIFF
--- a/HubSpot.NET/Api/CustomObject/EquipmentObjectModel.cs
+++ b/HubSpot.NET/Api/CustomObject/EquipmentObjectModel.cs
@@ -109,7 +109,7 @@ public class HubspotEquipmentObjectModel : IHubSpotModel
     public string? MakeOther { get; set; }
 
     [DataMember(Name = "new_associated_deal")]
-    public bool? NewAssociatedDeal { get; set; }
+    public DateTime? NewAssociatedDeal { get; set; }
 
     [DataMember(Name = "photo")]
     public string? Photo { get; set; }


### PR DESCRIPTION
## Description
fixes serialization / deserialization issues with equipment object

## Purpose
- [ ] Bugfix - change type of NewAssociatedDeal to match HubSpot field (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
