### PR TITLE
Upgrade to .Net 8 & newer versions of RestSharp, NewtonSoft

### DIFF
--- a/HubSpot.NET/Api/Associations/Dto/AssociationListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Associations/Dto/AssociationListHubSpotModel.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using HubSpot.NET.Core.Interfaces;
+using Newtonsoft.Json;
+
+namespace HubSpot.NET.Api.Associations.Dto
+{
+    public class AssociationListHubSpotModel: IHubSpotModel
+    {
+        [DataMember(Name = "results"), JsonProperty(PropertyName = "results")]
+        public IList<AssociationHubSpotModel> Associations { get; set; } = new List<AssociationHubSpotModel>();
+
+        public bool IsNameValue => false;
+
+        public string RouteBasePath => "/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}";
+
+        public void FromHubSpotDataEntity(dynamic hubspotData)
+        {
+        }
+
+        public void ToHubSpotDataEntity(ref dynamic dataEntity)
+        {
+        }
+    }
+
+    public class AssociationHubSpotModel
+    {
+        [DataMember(Name = "toObjectId")]
+        public Int64 ToObjectId { get; set; }
+        [DataMember(Name = "associationTypes")]
+        public IList<AssociationType> AssociationTypes { get; set; } = new List<AssociationType>();
+
+    }
+
+    public class AssociationType
+    {
+        [DataMember(Name = "category")]
+        public AssociationCategory Category { get; set; }
+        [DataMember(Name = "typeId")]
+        public int TypeId { get; set; }
+        [DataMember(Name = "label")]
+        public string Label { get; set; }
+    }
+
+    public enum AssociationCategory
+    {
+        HUBSPOT_DEFINED,
+        USER_DEFINED
+    }
+}

--- a/HubSpot.NET/Api/Associations/Dto/AssociationListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Associations/Dto/AssociationListHubSpotModel.cs
@@ -27,6 +27,24 @@ namespace HubSpot.NET.Api.Associations.Dto
         }
     }
 
+    public class AssociationTypeListHubSpotModel : IHubSpotModel
+    {
+        [DataMember(Name = "results"), JsonProperty(PropertyName = "results")]
+        public IList<AssociationType> AssociationTypes { get; set; } = new List<AssociationType>();
+
+        public bool IsNameValue => false;
+
+        public string RouteBasePath => "/crm/v4/associations/{fromObjectType}/{toObjectType}/labels";
+
+        public void FromHubSpotDataEntity(dynamic hubspotData)
+        {
+        }
+
+        public void ToHubSpotDataEntity(ref dynamic dataEntity)
+        {
+        }
+    }
+
     public class AssociationHubSpotModel
     {
         [DataMember(Name = "toObjectId")]

--- a/HubSpot.NET/Api/Associations/Dto/DeleteAssociationToObjectByLabelRequest.cs
+++ b/HubSpot.NET/Api/Associations/Dto/DeleteAssociationToObjectByLabelRequest.cs
@@ -1,0 +1,65 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HubSpot.NET.Api.Associations.Dto
+{
+    internal class DeleteAssociationToObjectByLabelRequest
+    {
+        [JsonProperty(PropertyName = "inputs")]
+        internal List<DeleteRequestInput> Inputs { get; set; }
+
+        internal DeleteAssociationToObjectByLabelRequest(string objectId, string toObjectId, (string associationCategory, int associationTypeId)[] associations)
+        {
+            Inputs =
+            [
+                new DeleteRequestInput
+                {
+                    From = new DeleteRequestObjectReference() { Id = long.Parse(objectId) },
+                    To = new DeleteRequestObjectReference() { Id = long.Parse(toObjectId) },
+                    Types = []
+                }
+            ];
+
+            foreach (var association in associations)
+            {
+                Inputs[0].Types.Add(
+                    new DeleteRequestType()
+                    {
+                        AssociationCategory = association.associationCategory,
+                        AssociationTypeId = association.associationTypeId
+                    });
+            }
+        }
+    }
+
+    internal class DeleteRequestInput
+    {
+        [JsonProperty(PropertyName = "types")]
+        internal List<DeleteRequestType> Types { get; set; }
+
+        [JsonProperty(PropertyName = "from")]
+        internal DeleteRequestObjectReference From { get; set; }
+
+        [JsonProperty(PropertyName = "to")]
+        internal DeleteRequestObjectReference To { get; set; }
+    }
+
+    internal class DeleteRequestType
+    {
+        [JsonProperty(PropertyName = "associationCategory")]
+        internal string AssociationCategory { get; set; }
+
+        [JsonProperty(PropertyName = "associationTypeId")]
+        internal int AssociationTypeId { get; set; }
+    }
+
+    internal class DeleteRequestObjectReference
+    {
+        [JsonProperty(PropertyName = "id")]
+        internal long Id { get; set; }
+    }
+}

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -23,7 +23,7 @@ public class HubSpotAssociationsApi : IHubSpotAssociationsApi
     {
         var associationPath =
             $"/crm/v4/objects/{objectType}/{objectId}/associations/default/{toObjectType}/{toObjectId}";
-        _client.Execute(associationPath, null, Method.PUT, convertToPropertiesSchema: false);
+        _client.Execute(associationPath, null, Method.Put, convertToPropertiesSchema: false);
         
     }
 
@@ -47,7 +47,7 @@ public class HubSpotAssociationsApi : IHubSpotAssociationsApi
             associationTypeId
         };
         var body = new[] {label};
-        _client.Execute(associationPath, body, Method.PUT, convertToPropertiesSchema: false);
+        _client.Execute(associationPath, body, Method.Put, convertToPropertiesSchema: false);
         
     }
     

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using HubSpot.NET.Api.Associations.Dto;
 using HubSpot.NET.Core.Interfaces;
 using RestSharp;
 
@@ -5,6 +7,20 @@ namespace HubSpot.NET.Api.Associations;
 
 public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociationsApi
 {
+    /// <summary>
+    /// Gets associations to a specific object type
+    /// </summary>
+    /// <param name="objectType">the type of the object you're fetching associations (e.g. contact).</param>
+    /// <param name="objectId"> the ID of the record to find associations for.</param>
+    /// <param name="toObjectType"> the type of the object you are fetching associations for.</param>
+    public AssociationListHubSpotModel List(string objectType, string objectId, string toObjectType)
+    {
+        var associationPath =
+            $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}";
+        return client.ExecuteList<AssociationListHubSpotModel>(associationPath, null, Method.Get, convertToPropertiesSchema: false);
+
+    }
+
     /// <summary>
     /// Adds the ability to associate via the default association
     /// See the PUT documentation here: https://developers.hubspot.com/docs/api/crm/associations
@@ -17,7 +33,7 @@ public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociation
     {
         var associationPath =
             $"/crm/v4/objects/{objectType}/{objectId}/associations/default/{toObjectType}/{toObjectId}";
-        client.Execute(associationPath, null, Method.Put, convertToPropertiesSchema: false);
+        client.Execute(associationPath, null, Method.Get, convertToPropertiesSchema: false);
         
     }
 

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -3,14 +3,8 @@ using RestSharp;
 
 namespace HubSpot.NET.Api.Associations;
 
-public class HubSpotAssociationsApi : IHubSpotAssociationsApi
+public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociationsApi
 {
-    private readonly IHubSpotClient _client;
-    public HubSpotAssociationsApi(IHubSpotClient client)
-    {
-        _client = client;
-    }
-    
     /// <summary>
     /// Adds the ability to associate via the default association
     /// See the PUT documentation here: https://developers.hubspot.com/docs/api/crm/associations
@@ -23,7 +17,7 @@ public class HubSpotAssociationsApi : IHubSpotAssociationsApi
     {
         var associationPath =
             $"/crm/v4/objects/{objectType}/{objectId}/associations/default/{toObjectType}/{toObjectId}";
-        _client.Execute(associationPath, null, Method.Put, convertToPropertiesSchema: false);
+        client.Execute(associationPath, null, Method.Put, convertToPropertiesSchema: false);
         
     }
 
@@ -47,7 +41,7 @@ public class HubSpotAssociationsApi : IHubSpotAssociationsApi
             associationTypeId
         };
         var body = new[] {label};
-        _client.Execute(associationPath, body, Method.Put, convertToPropertiesSchema: false);
+        client.Execute(associationPath, body, Method.Put, convertToPropertiesSchema: false);
         
     }
     

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -8,6 +8,19 @@ namespace HubSpot.NET.Api.Associations;
 public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociationsApi
 {
     /// <summary>
+    /// Gets association types between 2 object types
+    /// </summary>
+    /// <param name="fromObjectType">the type of the object you're fetching associations (e.g. contact) from.</param>
+    /// <param name="toObjectType"> the type of the object you are fetching associations to.</param>
+    public AssociationTypeListHubSpotModel ListTypes(string fromObjectType, string toObjectType)
+    {
+        var associationPath =
+            $"/crm/v4/associations/{fromObjectType}/{toObjectType}/labels";
+        return client.ExecuteList<AssociationTypeListHubSpotModel>(associationPath, null, Method.Get, convertToPropertiesSchema: false);
+
+    }
+
+    /// <summary>
     /// Gets associations to a specific object type
     /// </summary>
     /// <param name="objectType">the type of the object you're fetching associations (e.g. contact).</param>

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -32,16 +32,15 @@ public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociation
         
     }
 
-    public void AssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId, string associationCategory, int associationTypeId)
+    public void AssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId, AssociationType[] associationTypes)
     {
         var associationPath =
             $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}/{toObjectId}";
-        var label = new
+        var body = associationTypes.Select(associationType => new
         {
-            associationCategory,
-            associationTypeId
-        };
-        var body = new[] {label};
+            associationCategory = associationType.Category,
+            associationTypeId = associationType.TypeId
+        });
         client.Execute(associationPath, body, Method.Put, convertToPropertiesSchema: false);
         
     }

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using HubSpot.NET.Api.Associations.Dto;
 using HubSpot.NET.Core.Interfaces;
 using RestSharp;
@@ -7,11 +8,6 @@ namespace HubSpot.NET.Api.Associations;
 
 public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociationsApi
 {
-    /// <summary>
-    /// Gets association types between 2 object types
-    /// </summary>
-    /// <param name="fromObjectType">the type of the object you're fetching associations (e.g. contact) from.</param>
-    /// <param name="toObjectType"> the type of the object you are fetching associations to.</param>
     public AssociationTypeListHubSpotModel ListTypes(string fromObjectType, string toObjectType)
     {
         var associationPath =
@@ -20,12 +16,6 @@ public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociation
 
     }
 
-    /// <summary>
-    /// Gets associations to a specific object type
-    /// </summary>
-    /// <param name="objectType">the type of the object you're fetching associations (e.g. contact).</param>
-    /// <param name="objectId"> the ID of the record to find associations for.</param>
-    /// <param name="toObjectType"> the type of the object you are fetching associations for.</param>
     public AssociationListHubSpotModel List(string objectType, string objectId, string toObjectType)
     {
         var associationPath =
@@ -34,14 +24,6 @@ public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociation
 
     }
 
-    /// <summary>
-    /// Adds the ability to associate via the default association
-    /// See the PUT documentation here: https://developers.hubspot.com/docs/api/crm/associations
-    /// </summary>
-    /// <param name="objectType">the type of the object you're associating (e.g. contact).</param>
-    /// <param name="objectId"> the ID of the record to associate.</param>
-    /// <param name="toObjectType"> the ID of the record to associate.</param>
-    /// <param name="toObjectId"> the ID of the record to associate.</param>
     public void AssociationToObject(string objectType, string objectId, string toObjectType, string toObjectId)
     {
         var associationPath =
@@ -50,16 +32,6 @@ public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociation
         
     }
 
-    /// <summary>
-    /// Adds the ability to associate via the label association association
-    /// See the PUT documentation here: https://developers.hubspot.com/docs/api/crm/associations
-    /// </summary>
-    /// <param name="objectType">the type of the object you're associating (e.g. contact).</param>
-    /// <param name="objectId"> the ID of the record to associate.</param>
-    /// <param name="toObjectType"> the ID of the record to associate.</param>
-    /// <param name="toObjectId"> the ID of the record to associate.</param>
-    /// <param name="associationCategory">Category type: HUBSPOT_DEFINED, INTEGRATOR_DEFINED, USER_DEFINED</param>
-    /// <param name="associationTypeId">This is the ID of the label, can be hard to find, the url of the label in your settings is a good place to look</param>
     public void AssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId, string associationCategory, int associationTypeId)
     {
         var associationPath =
@@ -73,5 +45,19 @@ public class HubSpotAssociationsApi(IHubSpotClient client) : IHubSpotAssociation
         client.Execute(associationPath, body, Method.Put, convertToPropertiesSchema: false);
         
     }
-    
+
+    public void DeleteAssociationToObject(string objectType, string objectId, string toObjectType, string toObjectId)
+    {
+        var associationPath =
+            $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}/{toObjectId}";
+        client.Execute(associationPath, null, Method.Delete, convertToPropertiesSchema: false);
+    }
+
+    public void DeleteAssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId, (string associationCategory, int associationTypeId)[] associations)
+    {
+        var associationPath =
+            $"/crm/v4/associations/{objectType}/{toObjectType}/batch/labels/archive";
+        var body = new DeleteAssociationToObjectByLabelRequest(objectId, toObjectId, associations);
+        client.Execute(associationPath, body, Method.Post, convertToPropertiesSchema: false);
+    }
 }

--- a/HubSpot.NET/Api/Company/CompanyListRequestOptions.cs
+++ b/HubSpot.NET/Api/Company/CompanyListRequestOptions.cs
@@ -30,7 +30,7 @@ namespace HubSpot.NET.Api.Company
     public class CompanySearchByDomainRequestOptions
     {
         [DataMember(Name = "properties")]
-        public List<string> Properties { get; set; } = new() { "domain", "name", "website" };
+        public List<string> Properties { get; set; } = ["domain", "name", "website"];
     }
 
     [DataContract]

--- a/HubSpot.NET/Api/Company/CompanyListRequestOptions.cs
+++ b/HubSpot.NET/Api/Company/CompanyListRequestOptions.cs
@@ -13,10 +13,10 @@ namespace HubSpot.NET.Api.Company
         public int Limit { get; set; } = 100;
 
         [DataMember(Name = "requestOptions")]
-        public CompanySearchByDomainRequestOptions RequestOptions { get; set; } = new CompanySearchByDomainRequestOptions();
+        public CompanySearchByDomainRequestOptions RequestOptions { get; set; } = new();
 
         [DataMember(Name = "offset")]
-        public CompanySearchOffset Offset { get; set; } = new CompanySearchOffset();
+        public CompanySearchOffset Offset { get; set; } = new();
 
         public string RouteBasePath => "/companies/v2";
         public bool IsNameValue => true;
@@ -30,7 +30,7 @@ namespace HubSpot.NET.Api.Company
     public class CompanySearchByDomainRequestOptions
     {
         [DataMember(Name = "properties")]
-        public List<string> Properties { get; set; } = new List<string> { "domain", "name", "website" };
+        public List<string> Properties { get; set; } = new() { "domain", "name", "website" };
     }
 
     [DataContract]

--- a/HubSpot.NET/Api/Company/Dto/CompanyHubSpotModel.cs
+++ b/HubSpot.NET/Api/Company/Dto/CompanyHubSpotModel.cs
@@ -13,10 +13,6 @@ namespace HubSpot.NET.Api.Company.Dto
     [DataContract]
     public class CompanyHubSpotModel : IHubSpotModel
     {
-        public CompanyHubSpotModel()
-        {
-            Associations = new();
-        }
         [DataMember(Name = "companyId")]
         [IgnoreDataMember]
         public long? Id { get; set; }
@@ -48,7 +44,7 @@ namespace HubSpot.NET.Api.Company.Dto
         public bool IsNameValue => true;
 
         [IgnoreDataMember]
-        public CompanyHubSpotAssociations Associations { get; }
+        public CompanyHubSpotAssociations Associations { get; } = new();
 
         public virtual void ToHubSpotDataEntity(ref dynamic converted)
         {

--- a/HubSpot.NET/Api/Company/Dto/CompanyHubSpotModel.cs
+++ b/HubSpot.NET/Api/Company/Dto/CompanyHubSpotModel.cs
@@ -15,7 +15,7 @@ namespace HubSpot.NET.Api.Company.Dto
     {
         public CompanyHubSpotModel()
         {
-            Associations = new CompanyHubSpotAssociations();
+            Associations = new();
         }
         [DataMember(Name = "companyId")]
         [IgnoreDataMember]

--- a/HubSpot.NET/Api/Company/Dto/SearchRequestFilter.cs
+++ b/HubSpot.NET/Api/Company/Dto/SearchRequestFilter.cs
@@ -9,14 +9,9 @@ namespace HubSpot.NET.Api.Company.Dto
         public string PropertyName { get; set; }
 
         [DataMember(Name = "operator")]
-        public string Operator { get; set; }
+        public string Operator { get; set; } = "EQ";
 
         [DataMember(Name = "value")]
         public string Value { get; set; }
-
-        public SearchRequestFilter()
-        {
-            Operator = "EQ";
-        }
     }
 }

--- a/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
+++ b/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
@@ -30,7 +30,7 @@ namespace HubSpot.NET.Api.Company
         {
             var path = $"{entity.RouteBasePath}/companies";
 
-            return _client.Execute<T>(path, entity, Method.POST, convertToPropertiesSchema: true);
+            return _client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace HubSpot.NET.Api.Company
 
             try
             {
-                return _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: true);
+                return _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
              }
             catch (HubSpotException exception)
             {
@@ -64,15 +64,14 @@ namespace HubSpot.NET.Api.Company
         /// <returns>The company entity or null if the company does not exist</returns>
         public CompanySearchResultModel<T> GetByDomain<T>(string domain, CompanySearchByDomain options = null) where T : CompanyHubSpotModel, new()
         {
-            if (options == null)
-                options = new CompanySearchByDomain();
+            options ??= new();
 
             var path =  $"{new CompanyHubSpotModel().RouteBasePath}/domains/{domain}/companies";
 
             try
             {
 
-                CompanySearchResultModel<T> data = _client.ExecuteList<CompanySearchResultModel<T>>(path, options, Method.POST, convertToPropertiesSchema: true);
+                CompanySearchResultModel<T> data = _client.ExecuteList<CompanySearchResultModel<T>>(path, options, Method.Post, convertToPropertiesSchema: true);
 
                 return data;
              }
@@ -86,8 +85,7 @@ namespace HubSpot.NET.Api.Company
 
         public CompanyListHubSpotModel<T> List<T>(ListRequestOptions opts = null) where T: CompanyHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new ListRequestOptions();
+            opts ??= new();
 
             var path = $"{new CompanyHubSpotModel().RouteBasePath}/companies/paged"
                 .SetQueryParam("count", opts.Limit);
@@ -116,7 +114,7 @@ namespace HubSpot.NET.Api.Company
 
             var path = $"{entity.RouteBasePath}/companies/{entity.Id}";
 
-            T data = _client.Execute<T>(path, entity, Method.PUT, convertToPropertiesSchema: true);
+            T data = _client.Execute<T>(path, entity, Method.Put, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -129,17 +127,16 @@ namespace HubSpot.NET.Api.Company
         {
             var path = $"{new CompanyHubSpotModel().RouteBasePath}/companies/{companyId}";
 
-            _client.Execute(path, method: Method.DELETE, convertToPropertiesSchema: true);
+            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         public CompanySearchHubSpotModel<T> Search<T>(SearchRequestOptions opts = null) where T : CompanyHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new SearchRequestOptions();
+            opts ??= new();
 
             var path = "/crm/v3/objects/companies/search";
 
-			CompanySearchHubSpotModel<T> data = _client.ExecuteList<CompanySearchHubSpotModel<T>>(path, opts, Method.POST, convertToPropertiesSchema: true);
+			CompanySearchHubSpotModel<T> data = _client.ExecuteList<CompanySearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: true);
 
             return data;
         }

--- a/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
+++ b/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
@@ -10,15 +10,8 @@ namespace HubSpot.NET.Api.Company
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
-    public class HubSpotCompanyApi : IHubSpotCompanyApi
+    public class HubSpotCompanyApi(IHubSpotClient client) : IHubSpotCompanyApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotCompanyApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         /// <summary>
         /// Creates a Company entity
         /// </summary>
@@ -30,7 +23,7 @@ namespace HubSpot.NET.Api.Company
         {
             var path = $"{entity.RouteBasePath}/companies";
 
-            return _client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
+            return client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -45,7 +38,7 @@ namespace HubSpot.NET.Api.Company
 
             try
             {
-                return _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
+                return client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
              }
             catch (HubSpotException exception)
             {
@@ -71,7 +64,7 @@ namespace HubSpot.NET.Api.Company
             try
             {
 
-                CompanySearchResultModel<T> data = _client.ExecuteList<CompanySearchResultModel<T>>(path, options, Method.Post, convertToPropertiesSchema: true);
+                CompanySearchResultModel<T> data = client.ExecuteList<CompanySearchResultModel<T>>(path, options, Method.Post, convertToPropertiesSchema: true);
 
                 return data;
              }
@@ -96,7 +89,7 @@ namespace HubSpot.NET.Api.Company
             if (opts.Offset.HasValue)
                 path = path.SetQueryParam("offset", opts.Offset);
 
-			CompanyListHubSpotModel<T> data = _client.ExecuteList<CompanyListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
+			CompanyListHubSpotModel<T> data = client.ExecuteList<CompanyListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -114,7 +107,7 @@ namespace HubSpot.NET.Api.Company
 
             var path = $"{entity.RouteBasePath}/companies/{entity.Id}";
 
-            T data = _client.Execute<T>(path, entity, Method.Put, convertToPropertiesSchema: true);
+            T data = client.Execute<T>(path, entity, Method.Put, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -127,7 +120,7 @@ namespace HubSpot.NET.Api.Company
         {
             var path = $"{new CompanyHubSpotModel().RouteBasePath}/companies/{companyId}";
 
-            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
+            client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         public CompanySearchHubSpotModel<T> Search<T>(SearchRequestOptions opts = null) where T : CompanyHubSpotModel, new()
@@ -136,7 +129,7 @@ namespace HubSpot.NET.Api.Company
 
             var path = "/crm/v3/objects/companies/search";
 
-			CompanySearchHubSpotModel<T> data = _client.ExecuteList<CompanySearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: true);
+			CompanySearchHubSpotModel<T> data = client.ExecuteList<CompanySearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -155,7 +148,7 @@ namespace HubSpot.NET.Api.Company
             var dealResults = new List<long>();
             do
             {
-                var dealAssociations = _client.ExecuteList<AssociationIdListHubSpotModel>(string.Format("{0}?limit=100{1}", companyPath, offSet == null ? null : "&offset=" + offSet), convertToPropertiesSchema: false);
+                var dealAssociations = client.ExecuteList<AssociationIdListHubSpotModel>(string.Format("{0}?limit=100{1}", companyPath, offSet == null ? null : "&offset=" + offSet), convertToPropertiesSchema: false);
                 if (dealAssociations.Results.Any())
                     dealResults.AddRange(dealAssociations.Results);
                 if (dealAssociations.HasMore)
@@ -174,7 +167,7 @@ namespace HubSpot.NET.Api.Company
             var contactResults = new List<long>();
             do
             {
-                var contactAssociations = _client.ExecuteList<AssociationIdListHubSpotModel>(string.Format("{0}?limit=100{1}", contactPath, offSet == null ? null : "&offset=" + offSet), convertToPropertiesSchema: false);
+                var contactAssociations = client.ExecuteList<AssociationIdListHubSpotModel>(string.Format("{0}?limit=100{1}", contactPath, offSet == null ? null : "&offset=" + offSet), convertToPropertiesSchema: false);
                 if (contactAssociations.Results.Any())
                     contactResults.AddRange(contactAssociations.Results);
                 if (contactAssociations.HasMore)

--- a/HubSpot.NET/Api/Contact/Dto/ContactSearchRequestOptions.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ContactSearchRequestOptions.cs
@@ -20,11 +20,6 @@ namespace HubSpot.NET.Api.Contact.Dto
         /// <summary>
         /// (defaults to "DESC") The order results are ordered by with respect to <see cref="SortBy"/>.
         /// </summary>
-        public SortingOrderType Order { get; set; }
-
-        public ContactSearchRequestOptions()
-		{
-            Order = SortingOrderType.Descending;
-        }
+        public SortingOrderType Order { get; set; } = SortingOrderType.Descending;
     }
 }

--- a/HubSpot.NET/Api/Contact/Dto/ListRecentRequestOptions.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ListRecentRequestOptions.cs
@@ -30,7 +30,7 @@ namespace HubSpot.NET.Api.Contact.Dto
 
         public ListRecentRequestOptions()
 		{
-            PropertiesToInclude = new List<string> { "createdate", "lastmodifieddate", "firstname", "lastname", "email", "company" };
+            PropertiesToInclude = new() { "createdate", "lastmodifieddate", "firstname", "lastname", "email", "company" };
 		}
     }
 }

--- a/HubSpot.NET/Api/Contact/Dto/ListRecentRequestOptions.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ListRecentRequestOptions.cs
@@ -30,7 +30,7 @@ namespace HubSpot.NET.Api.Contact.Dto
 
         public ListRecentRequestOptions()
 		{
-            PropertiesToInclude = new() { "createdate", "lastmodifieddate", "firstname", "lastname", "email", "company" };
+            PropertiesToInclude = ["createdate", "lastmodifieddate", "firstname", "lastname", "email", "company"];
 		}
     }
 }

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -12,16 +12,9 @@
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
-   public class HubSpotContactApi : IHubSpotContactApi
-    {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotContactApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
-        /// <summary>
+   public class HubSpotContactApi(IHubSpotClient client) : IHubSpotContactApi
+   {
+       /// <summary>
         /// Creates a contact entity
         /// </summary>
         /// <typeparam name="T">Implementation of ContactHubSpotModel</typeparam>
@@ -31,7 +24,7 @@
         public T Create<T>(T entity) where T : ContactHubSpotModel, new()
         {
             var path = $"{entity.RouteBasePath}/contact";
-            return _client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
+            return client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -43,7 +36,7 @@
         public T CreateOrUpdate<T>(T entity) where T : ContactHubSpotModel, new()
         {
             var path = $"{entity.RouteBasePath}/contact/createOrUpdate/email/{entity.Email}/";
-            return _client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
+            return client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -58,7 +51,7 @@
 
             try
             {
-                T data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
+                T data = client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
                 return data;
              }
             catch (HubSpotException exception)
@@ -81,7 +74,7 @@
 
             try
             {
-                T data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
+                T data = client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
                 return data;
              }
             catch (HubSpotException exception)
@@ -104,7 +97,7 @@
 
             try
             {
-                T data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
+                T data = client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
                 return data;
             }
             catch (HubSpotException exception)
@@ -135,7 +128,7 @@
             if (opts.Offset.HasValue)
                 path = path.SetQueryParam("vidOffset", opts.Offset);
 
-			ContactListHubSpotModel<T> data = _client.ExecuteList<ContactListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
+			ContactListHubSpotModel<T> data = client.ExecuteList<ContactListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -152,7 +145,7 @@
 
             var path = $"{contact.RouteBasePath}/contact/vid/{contact.Id}/profile";
 
-            _client.Execute(path, contact, Method.Post, convertToPropertiesSchema: true);
+            client.Execute(path, contact, Method.Post, convertToPropertiesSchema: true);
         }
         
         /// <summary>
@@ -163,7 +156,7 @@
         {
             var path = $"{new ContactHubSpotModel().RouteBasePath}/contact/vid/{contactId}";
 
-            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
+            client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -176,7 +169,7 @@
         {
             var path =  $"{new T().RouteBasePath}/contact/batch";
 
-            _client.ExecuteBatch(path, contacts.Select(c => (object) c).ToList(), Method.Post, convertToPropertiesSchema: true);
+            client.ExecuteBatch(path, contacts.Select(c => (object) c).ToList(), Method.Post, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -204,7 +197,7 @@
             
             path = path.SetQueryParam("showListMemberships", opts.ShowListMemberships);
 
-			ContactListHubSpotModel<T> data = _client.ExecuteList<ContactListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: true);
+			ContactListHubSpotModel<T> data = client.ExecuteList<ContactListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -237,7 +230,7 @@
                 path = path.SetQueryParam("order", description);
             }
 
-            ContactSearchHubSpotModel<T> data = _client.ExecuteList<ContactSearchHubSpotModel<T>>(path, convertToPropertiesSchema: true);
+            ContactSearchHubSpotModel<T> data = client.ExecuteList<ContactSearchHubSpotModel<T>>(path, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -267,7 +260,7 @@
             
             path = path.SetQueryParam("showListMemberships", opts.ShowListMemberships);
 
-			ContactListHubSpotModel<T> data = _client.ExecuteList<ContactListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: true);
+			ContactListHubSpotModel<T> data = client.ExecuteList<ContactListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: true);
 
             return data;
         }

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -31,7 +31,7 @@
         public T Create<T>(T entity) where T : ContactHubSpotModel, new()
         {
             var path = $"{entity.RouteBasePath}/contact";
-            return _client.Execute<T>(path, entity, Method.POST, convertToPropertiesSchema: true);
+            return _client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@
         public T CreateOrUpdate<T>(T entity) where T : ContactHubSpotModel, new()
         {
             var path = $"{entity.RouteBasePath}/contact/createOrUpdate/email/{entity.Email}/";
-            return _client.Execute<T>(path, entity, Method.POST, convertToPropertiesSchema: true);
+            return _client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@
 
             try
             {
-                T data = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: true);
+                T data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
                 return data;
              }
             catch (HubSpotException exception)
@@ -81,7 +81,7 @@
 
             try
             {
-                T data = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: true);
+                T data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
                 return data;
              }
             catch (HubSpotException exception)
@@ -104,7 +104,7 @@
 
             try
             {
-                T data = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: true);
+                T data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
                 return data;
             }
             catch (HubSpotException exception)
@@ -124,8 +124,7 @@
         /// <returns>A list of contacts</returns>
         public ContactListHubSpotModel<T> List<T>(ListRequestOptions opts = null) where T : ContactHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new ListRequestOptions();
+            opts ??= new();
 
             var path = $"{new ContactHubSpotModel().RouteBasePath}/lists/all/contacts/all"
                 .SetQueryParam("count", opts.Limit);
@@ -153,7 +152,7 @@
 
             var path = $"{contact.RouteBasePath}/contact/vid/{contact.Id}/profile";
 
-            _client.Execute(path, contact, Method.POST, convertToPropertiesSchema: true);
+            _client.Execute(path, contact, Method.Post, convertToPropertiesSchema: true);
         }
         
         /// <summary>
@@ -164,7 +163,7 @@
         {
             var path = $"{new ContactHubSpotModel().RouteBasePath}/contact/vid/{contactId}";
 
-            _client.Execute(path, method: Method.DELETE, convertToPropertiesSchema: true);
+            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -177,7 +176,7 @@
         {
             var path =  $"{new T().RouteBasePath}/contact/batch";
 
-            _client.ExecuteBatch(path, contacts.Select(c => (object) c).ToList(), Method.POST, convertToPropertiesSchema: true);
+            _client.ExecuteBatch(path, contacts.Select(c => (object) c).ToList(), Method.Post, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -185,8 +184,7 @@
         /// </summary>
         public ContactListHubSpotModel<T> RecentlyUpdated<T>(ListRecentRequestOptions opts = null) where T : ContactHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new ListRecentRequestOptions();
+            opts ??= new();
 
             var path = $"{new ContactHubSpotModel().RouteBasePath}/lists/recently_updated/contacts/recent"
                 .SetQueryParam("count", opts.Limit);
@@ -214,8 +212,7 @@
         public ContactSearchHubSpotModel<T> Search<T>(ContactSearchRequestOptions opts = null)
             where T : ContactHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new ContactSearchRequestOptions();
+            opts ??= new();
 
             var path = $"{new T().RouteBasePath}/search/query"
                 .SetQueryParam("q", opts.Query)
@@ -250,8 +247,7 @@
         /// </summary>
         public ContactListHubSpotModel<T> RecentlyCreated<T>(ListRecentRequestOptions opts = null) where T : ContactHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new ListRecentRequestOptions();
+            opts ??= new();
 
             var path = $"{new ContactHubSpotModel().RouteBasePath}/lists/all/contacts/recent"
                 .SetQueryParam("count", opts.Limit);

--- a/HubSpot.NET/Api/ContactList/Dto/ContactListUpdateModel.cs
+++ b/HubSpot.NET/Api/ContactList/Dto/ContactListUpdateModel.cs
@@ -8,7 +8,7 @@ namespace HubSpot.NET.Api.ContactList.Dto
     public class ContactListUpdateModel : IHubSpotModel
     {
         [DataMember(Name = "vids")] 
-        public List<long> ContactIds = new();
+        public List<long> ContactIds = [];
 
         [IgnoreDataMember]
         public bool IsNameValue => false;

--- a/HubSpot.NET/Api/ContactList/Dto/ContactListUpdateModel.cs
+++ b/HubSpot.NET/Api/ContactList/Dto/ContactListUpdateModel.cs
@@ -8,7 +8,7 @@ namespace HubSpot.NET.Api.ContactList.Dto
     public class ContactListUpdateModel : IHubSpotModel
     {
         [DataMember(Name = "vids")] 
-        public List<long> ContactIds = new List<long>();
+        public List<long> ContactIds = new();
 
         [IgnoreDataMember]
         public bool IsNameValue => false;

--- a/HubSpot.NET/Api/ContactList/Dto/ContactListUpdateResponseModel.cs
+++ b/HubSpot.NET/Api/ContactList/Dto/ContactListUpdateResponseModel.cs
@@ -8,13 +8,13 @@ namespace HubSpot.NET.Api.ContactList.Dto
     public class ContactListUpdateResponseModel : IHubSpotModel
     {
         [DataMember(Name = "discarded")] 
-        public List<long> Discarded = new List<long>();
+        public List<long> Discarded = new();
 
         [DataMember(Name = "invalidVids")] 
-        public List<long> InvalidContactIds = new List<long>();
+        public List<long> InvalidContactIds = new();
 
         [DataMember(Name = "updated")] 
-        public List<long> UpdatedContactIds = new List<long>();
+        public List<long> UpdatedContactIds = new();
 
         [IgnoreDataMember]
         public bool IsNameValue => false;

--- a/HubSpot.NET/Api/ContactList/Dto/ContactListUpdateResponseModel.cs
+++ b/HubSpot.NET/Api/ContactList/Dto/ContactListUpdateResponseModel.cs
@@ -8,13 +8,13 @@ namespace HubSpot.NET.Api.ContactList.Dto
     public class ContactListUpdateResponseModel : IHubSpotModel
     {
         [DataMember(Name = "discarded")] 
-        public List<long> Discarded = new();
+        public List<long> Discarded = [];
 
         [DataMember(Name = "invalidVids")] 
-        public List<long> InvalidContactIds = new();
+        public List<long> InvalidContactIds = [];
 
         [DataMember(Name = "updated")] 
-        public List<long> UpdatedContactIds = new();
+        public List<long> UpdatedContactIds = [];
 
         [IgnoreDataMember]
         public bool IsNameValue => false;

--- a/HubSpot.NET/Api/ContactList/Dto/ListContactListModel.cs
+++ b/HubSpot.NET/Api/ContactList/Dto/ListContactListModel.cs
@@ -8,7 +8,7 @@ namespace HubSpot.NET.Api.ContactList.Dto
     public class ListContactListModel : IHubSpotModel
     {
         [DataMember(Name = "lists")]
-        public List<ContactListModel> Lists { get; set; } = new List<ContactListModel>();
+        public List<ContactListModel> Lists { get; set; } = new();
         
         /// <summary>
         /// Gets or sets a value indicating whether more results are available.

--- a/HubSpot.NET/Api/ContactList/Dto/ListContactListModel.cs
+++ b/HubSpot.NET/Api/ContactList/Dto/ListContactListModel.cs
@@ -8,7 +8,7 @@ namespace HubSpot.NET.Api.ContactList.Dto
     public class ListContactListModel : IHubSpotModel
     {
         [DataMember(Name = "lists")]
-        public List<ContactListModel> Lists { get; set; } = new();
+        public List<ContactListModel> Lists { get; set; } = [];
         
         /// <summary>
         /// Gets or sets a value indicating whether more results are available.

--- a/HubSpot.NET/Api/ContactList/HubSpotContactListApi.cs
+++ b/HubSpot.NET/Api/ContactList/HubSpotContactListApi.cs
@@ -33,10 +33,7 @@ namespace HubSpot.NET.Api.ContactList
         /// <returns>The data</returns>
         public ListContactListModel GetContactLists(ListOptions opts = null)
         {
-            if (opts == null)
-            {
-                opts = new ListOptions();
-            }
+            opts ??= new();
             
             var path = $"{new ListContactListModel().RouteBasePath}".SetQueryParam("count", opts.Limit);
             if (opts.Offset.HasValue)
@@ -56,10 +53,7 @@ namespace HubSpot.NET.Api.ContactList
         /// <returns>The data</returns>
         public ListContactListModel GetStaticContactLists(ListOptions opts = null)
         {
-            if (opts == null)
-            {
-                opts = new ListOptions();
-            }
+            opts ??= new();
             
             var path = $"{new ListContactListModel().RouteBasePath}/static".SetQueryParam("count", opts.Limit);
             if (opts.Offset.HasValue)
@@ -97,7 +91,7 @@ namespace HubSpot.NET.Api.ContactList
             var model = new ContactListUpdateModel();
             var path = $"{model.RouteBasePath}/{listId}/add";
             model.ContactIds.AddRange(contactIds);
-            var data = _client.Execute<ContactListUpdateResponseModel>(path, model, Method.POST, convertToPropertiesSchema: false);
+            var data = _client.Execute<ContactListUpdateResponseModel>(path, model, Method.Post, convertToPropertiesSchema: false);
 
             return data;
         }
@@ -113,7 +107,7 @@ namespace HubSpot.NET.Api.ContactList
             var model = new ContactListUpdateModel();
             var path = $"{model.RouteBasePath}/{listId}/remove";
             model.ContactIds.AddRange(contactIds);
-            var data = _client.Execute<ContactListUpdateResponseModel>(path, model, Method.POST, convertToPropertiesSchema: false);
+            var data = _client.Execute<ContactListUpdateResponseModel>(path, model, Method.Post, convertToPropertiesSchema: false);
 
             return data;
         }
@@ -125,7 +119,7 @@ namespace HubSpot.NET.Api.ContactList
         public void DeleteContactList(long listId)
         {
             var path = $"{new ContactListModel().RouteBasePath}/{listId}";
-            _client.Execute(path, method: Method.DELETE, convertToPropertiesSchema: true);
+            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -141,7 +135,7 @@ namespace HubSpot.NET.Api.ContactList
                 Dynamic = false
             };
             var path = $"{model.RouteBasePath}";
-            var data = _client.Execute<ContactListModel>(path, model, Method.POST, convertToPropertiesSchema: false);
+            var data = _client.Execute<ContactListModel>(path, model, Method.Post, convertToPropertiesSchema: false);
             return data;
         }
     }

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -109,7 +109,7 @@ public class CustomObjectHubSpotModel : IHubSpotModel
 
     [IgnoreDataMember]
     [JsonProperty(PropertyName = "properties")]
-    public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+    public Dictionary<string, string> Properties { get; set; } = new();
     public bool IsNameValue => false;
     public void ToHubSpotDataEntity(ref dynamic dataEntity)
     {
@@ -168,7 +168,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
     /// <returns></returns>
     public CustomObjectListHubSpotModel<T> List<T>(string idForCustomObject, ListRequestOptions opts = null) where T : CustomObjectHubSpotModel, new()
     {
-        opts ??= new ListRequestOptions();
+        opts ??= new();
 
         var path = $"{RouteBasePath}/{idForCustomObject}"
             .SetQueryParam("count", opts.Limit);
@@ -216,7 +216,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         var path = $"{RouteBasePath}/{entity.SchemaId}";
 
         var response =
-            _client.Execute<CreateCustomObjectHubSpotModel>(path, entity, Method.POST, convertToPropertiesSchema: false);
+            _client.Execute<CreateCustomObjectHubSpotModel>(path, entity, Method.Post, convertToPropertiesSchema: false);
 
         
         if (response.Properties.TryGetValue("hs_object_id", out var parsedId))
@@ -237,7 +237,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
     {
         var path = $"{RouteBasePath}/{entity.SchemaId}/{entity.Id}";
 
-        _client.Execute<UpdateCustomObjectHubSpotModel>(path, entity, Method.PATCH, convertToPropertiesSchema: false);
+        _client.Execute<UpdateCustomObjectHubSpotModel>(path, entity, Method.Patch, convertToPropertiesSchema: false);
         
         return string.Empty;
     }
@@ -253,7 +253,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
 
         path = path.SetQueryParam("properties", properties); //properties is comma seperated value of properties to include
 
-        var res = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: true);
+        var res = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
 
         return res;
     }

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -171,15 +171,15 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         opts ??= new();
 
         var path = $"{RouteBasePath}/{idForCustomObject}"
-            .SetQueryParam("count", opts.Limit);
+            .SetQueryParam("limit", opts.Limit);
 
         if (opts.PropertiesToInclude.Any())
-            path = path.SetQueryParam("property", opts.PropertiesToInclude);
+            path = path.SetQueryParam("properties", string.Join(',',opts.PropertiesToInclude));
 
         if (opts.Offset.HasValue)
-            path = path.SetQueryParam("vidOffset", opts.Offset);
+            path = path.SetQueryParam("after", opts.Offset);
 
-        var response = _client.ExecuteList<CustomObjectListHubSpotModel<T>>(path, convertToPropertiesSchema: false);
+        var response = _client.ExecuteList<CustomObjectListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
         return response;
     }
 
@@ -198,7 +198,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
     {
         var path = $"{RouteBasePath}/{objectTypeId}/{customObjectId}/associations/{idForDesiredAssociation}";
 
-        var response = _client.ExecuteList<CustomObjectListAssociationsModel<T>>(path, convertToPropertiesSchema:  false);
+        var response = _client.ExecuteList<CustomObjectListAssociationsModel<T>>(path, convertToPropertiesSchema:  true);
         return response;
     }
 
@@ -216,7 +216,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         var path = $"{RouteBasePath}/{entity.SchemaId}";
 
         var response =
-            _client.Execute<CreateCustomObjectHubSpotModel>(path, entity, Method.Post, convertToPropertiesSchema: false);
+            _client.Execute<CreateCustomObjectHubSpotModel>(path, entity, Method.Post, convertToPropertiesSchema: true);
 
         
         if (response.Properties.TryGetValue("hs_object_id", out var parsedId))
@@ -237,7 +237,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
     {
         var path = $"{RouteBasePath}/{entity.SchemaId}/{entity.Id}";
 
-        _client.Execute<UpdateCustomObjectHubSpotModel>(path, entity, Method.Patch, convertToPropertiesSchema: false);
+        _client.Execute<UpdateCustomObjectHubSpotModel>(path, entity, Method.Patch, convertToPropertiesSchema: true);
         
         return string.Empty;
     }

--- a/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
+++ b/HubSpot.NET/Api/CustomObject/HubSpotCustomObjectApi.cs
@@ -48,7 +48,7 @@ public class CreateCustomObjectHubSpotModel : IHubSpotModel
 
     public string RouteBasePath => "crm/v3/objects";
     [JsonProperty(PropertyName = "associations")]
-    public List<Association> Associations { get; set; } = new();
+    public List<Association> Associations { get; set; } = [];
 
     public class Association
     {
@@ -146,19 +146,11 @@ public class CustomObjectAssociationModel
 }
 
 
-public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
+public class HubSpotCustomObjectApi(IHubSpotClient client, IHubSpotAssociationsApi hubSpotAssociationsApi)
+    : IHubSpotCustomObjectApi
 {
-    private readonly IHubSpotClient _client;
-
     private readonly string RouteBasePath = "crm/v3/objects";
-    private readonly IHubSpotAssociationsApi _hubSpotAssociationsApi;
 
-    public HubSpotCustomObjectApi(IHubSpotClient client, IHubSpotAssociationsApi hubSpotAssociationsApi)
-    {
-        _client = client;
-        _hubSpotAssociationsApi = hubSpotAssociationsApi;
-    }
-    
     /// <summary>
     /// List all objects of a custom object type in your system
     /// </summary>
@@ -179,7 +171,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         if (opts.Offset.HasValue)
             path = path.SetQueryParam("after", opts.Offset);
 
-        var response = _client.ExecuteList<CustomObjectListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
+        var response = client.ExecuteList<CustomObjectListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
         return response;
     }
 
@@ -198,7 +190,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
     {
         var path = $"{RouteBasePath}/{objectTypeId}/{customObjectId}/associations/{idForDesiredAssociation}";
 
-        var response = _client.ExecuteList<CustomObjectListAssociationsModel<T>>(path, convertToPropertiesSchema:  true);
+        var response = client.ExecuteList<CustomObjectListAssociationsModel<T>>(path, convertToPropertiesSchema:  true);
         return response;
     }
 
@@ -216,12 +208,12 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
         var path = $"{RouteBasePath}/{entity.SchemaId}";
 
         var response =
-            _client.Execute<CreateCustomObjectHubSpotModel>(path, entity, Method.Post, convertToPropertiesSchema: true);
+            client.Execute<CreateCustomObjectHubSpotModel>(path, entity, Method.Post, convertToPropertiesSchema: true);
 
         
         if (response.Properties.TryGetValue("hs_object_id", out var parsedId))
         {
-            _hubSpotAssociationsApi.AssociationToObject(entity.SchemaId, parsedId.ToString(), associateObjectType, associateToObjectId);
+            hubSpotAssociationsApi.AssociationToObject(entity.SchemaId, parsedId.ToString(), associateObjectType, associateToObjectId);
             return parsedId.ToString();
         }
         return string.Empty;
@@ -237,7 +229,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
     {
         var path = $"{RouteBasePath}/{entity.SchemaId}/{entity.Id}";
 
-        _client.Execute<UpdateCustomObjectHubSpotModel>(path, entity, Method.Patch, convertToPropertiesSchema: true);
+        client.Execute<UpdateCustomObjectHubSpotModel>(path, entity, Method.Patch, convertToPropertiesSchema: true);
         
         return string.Empty;
     }
@@ -253,7 +245,7 @@ public class HubSpotCustomObjectApi : IHubSpotCustomObjectApi
 
         path = path.SetQueryParam("properties", properties); //properties is comma seperated value of properties to include
 
-        var res = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
+        var res = client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
 
         return res;
     }

--- a/HubSpot.NET/Api/Deal/Dto/DealHubSpotModel.cs
+++ b/HubSpot.NET/Api/Deal/Dto/DealHubSpotModel.cs
@@ -16,10 +16,6 @@ namespace HubSpot.NET.Api.Deal.Dto
     [DataContract]
     public class DealHubSpotModel : IHubSpotModel
     {
-        public DealHubSpotModel()
-        {
-            Associations =  new();
-        }
         /// <summary>
         /// Contacts unique Id in HubSpot
         /// </summary>
@@ -60,7 +56,7 @@ namespace HubSpot.NET.Api.Deal.Dto
         public bool? IsDeleted { get; set; }
 
         [IgnoreDataMember]
-        public DealHubSpotAssociations Associations { get; }
+        public DealHubSpotAssociations Associations { get; } = new();
 
         public string RouteBasePath => "/deals/v1";
         public bool IsNameValue => true;

--- a/HubSpot.NET/Api/Deal/Dto/DealHubSpotModel.cs
+++ b/HubSpot.NET/Api/Deal/Dto/DealHubSpotModel.cs
@@ -18,7 +18,7 @@ namespace HubSpot.NET.Api.Deal.Dto
     {
         public DealHubSpotModel()
         {
-            Associations =  new DealHubSpotAssociations();
+            Associations =  new();
         }
         /// <summary>
         /// Contacts unique Id in HubSpot

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -28,7 +28,7 @@
         public T Create<T>(T entity) where T : DealHubSpotModel, new()
         {
             var path = $"{entity.RouteBasePath}/deal";
-            var data = _client.Execute<T>(path, entity, Method.POST, convertToPropertiesSchema: true);
+            var data = _client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
             return data;
         }
 
@@ -44,7 +44,7 @@
 
             try
             {
-                var data = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: true);
+                var data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
                 return data;
             }
             catch (HubSpotException exception)
@@ -68,7 +68,7 @@
 
             var path = $"{entity.RouteBasePath}/deal/{entity.Id}";
 
-            var data = _client.Execute<T>(path, entity, method: Method.PUT, convertToPropertiesSchema: true);
+            var data = _client.Execute<T>(path, entity, method: Method.Put, convertToPropertiesSchema: true);
             return data;
         }
 
@@ -80,8 +80,7 @@
         /// <returns>List of deals</returns>
         public DealListHubSpotModel<T> List<T>(bool includeAssociations, ListRequestOptions opts = null) where T : DealHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new ListRequestOptions(250);
+            opts ??= new(250);
 
             var path = $"{new DealListHubSpotModel<T>().RouteBasePath}/deal/paged"
                 .SetQueryParam("limit", opts.Limit);
@@ -112,8 +111,7 @@
         /// <returns>List of deals</returns>
         public DealListHubSpotModel<T> ListAssociated<T>(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact") where T : DealHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new ListRequestOptions();
+            opts ??= new();
 
             var path = $"{new DealListHubSpotModel<T>().RouteBasePath}/deal/associated/{objectName}/{hubId}/paged"
                 .SetQueryParam("limit", opts.Limit);
@@ -140,7 +138,7 @@
         {
             var path = $"{new DealHubSpotModel().RouteBasePath}/deal/{dealId}";
 
-            _client.Execute(path, method: Method.DELETE, convertToPropertiesSchema: true);
+            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -152,8 +150,7 @@
         public DealRecentListHubSpotModel<T> RecentlyCreated<T>(DealRecentRequestOptions opts = null) where T : DealHubSpotModel, new()
         {
 
-            if (opts == null)
-                opts = new DealRecentRequestOptions();
+            opts ??= new();
 
             var path = $"{new DealRecentListHubSpotModel<T>().RouteBasePath}/deal/recent/created"
                 .SetQueryParam("count", opts.Limit);
@@ -180,8 +177,7 @@
         /// <returns>List of deals</returns>
         public DealRecentListHubSpotModel<T> RecentlyUpdated<T>(DealRecentRequestOptions opts = null) where T : DealHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new DealRecentRequestOptions();
+            opts ??= new();
 
             var path = $"{new DealRecentListHubSpotModel<T>().RouteBasePath}/deal/recent/modified"
                 .SetQueryParam("count", opts.Limit);
@@ -208,12 +204,11 @@
         /// <returns>List of deals</returns>
         public SearchHubSpotModel<T> Search<T>(SearchRequestOptions opts = null) where T : DealHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new SearchRequestOptions();
+            opts ??= new();
 
             var path = "/crm/v3/objects/deals/search";
 
-            var data = _client.ExecuteList<SearchHubSpotModel<T>>(path, opts, Method.POST, convertToPropertiesSchema: true);
+            var data = _client.ExecuteList<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -234,7 +229,7 @@
                 toObjectId = companyId,
                 category = "HUBSPOT_DEFINED",
                 definitionId = 5 // see https://legacydocs.hubspot.com/docs/methods/crm-associations/crm-associations-overview
-            }, method: Method.PUT, convertToPropertiesSchema: true);
+            }, method: Method.Put, convertToPropertiesSchema: true);
             entity.Associations.AssociatedCompany = new[] { companyId };
             return entity;
         }
@@ -255,7 +250,7 @@
                 toObjectId = contactId,
                 category = "HUBSPOT_DEFINED",
                 definitionId = 3 // see https://legacydocs.hubspot.com/docs/methods/crm-associations/crm-associations-overview
-            }, method: Method.PUT, convertToPropertiesSchema: true);
+            }, method: Method.Put, convertToPropertiesSchema: true);
             entity.Associations.AssociatedContacts = new[] { contactId };
             return entity;
         }

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -10,15 +10,8 @@
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
-    public class HubSpotDealApi : IHubSpotDealApi
+    public class HubSpotDealApi(IHubSpotClient client) : IHubSpotDealApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotDealApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         /// <summary>
         /// Creates a deal entity
         /// </summary>
@@ -28,7 +21,7 @@
         public T Create<T>(T entity) where T : DealHubSpotModel, new()
         {
             var path = $"{entity.RouteBasePath}/deal";
-            var data = _client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
+            var data = client.Execute<T>(path, entity, Method.Post, convertToPropertiesSchema: true);
             return data;
         }
 
@@ -44,7 +37,7 @@
 
             try
             {
-                var data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
+                var data = client.Execute<T>(path, Method.Get, convertToPropertiesSchema: true);
                 return data;
             }
             catch (HubSpotException exception)
@@ -68,7 +61,7 @@
 
             var path = $"{entity.RouteBasePath}/deal/{entity.Id}";
 
-            var data = _client.Execute<T>(path, entity, method: Method.Put, convertToPropertiesSchema: true);
+            var data = client.Execute<T>(path, entity, method: Method.Put, convertToPropertiesSchema: true);
             return data;
         }
 
@@ -94,7 +87,7 @@
             if (opts.PropertiesToInclude.Any())
                 path = path.SetQueryParam("properties", opts.PropertiesToInclude);
 
-            var data = _client.ExecuteList<DealListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
+            var data = client.ExecuteList<DealListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -125,7 +118,7 @@
             if (opts.PropertiesToInclude.Any())
                 path = path.SetQueryParam("properties", opts.PropertiesToInclude);
 
-            var data = _client.ExecuteList<DealListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: true);
+            var data = client.ExecuteList<DealListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -138,7 +131,7 @@
         {
             var path = $"{new DealHubSpotModel().RouteBasePath}/deal/{dealId}";
 
-            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
+            client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -164,7 +157,7 @@
             if (!string.IsNullOrEmpty(opts.Since))
                 path = path.SetQueryParam("since", opts.Since);
 
-            var data = _client.ExecuteList<DealRecentListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
+            var data = client.ExecuteList<DealRecentListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -191,7 +184,7 @@
             if (!string.IsNullOrEmpty(opts.Since))
                 path = path.SetQueryParam("since", opts.Since);
 
-            var data = _client.ExecuteList<DealRecentListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
+            var data = client.ExecuteList<DealRecentListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -208,7 +201,7 @@
 
             var path = "/crm/v3/objects/deals/search";
 
-            var data = _client.ExecuteList<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: true);
+            var data = client.ExecuteList<SearchHubSpotModel<T>>(path, opts, Method.Post, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -223,14 +216,14 @@
         {
             var path = "/crm-associations/v1/associations";
 
-            _client.Execute(path, new
+            client.Execute(path, new
             {
                 fromObjectId = entity.Id,
                 toObjectId = companyId,
                 category = "HUBSPOT_DEFINED",
                 definitionId = 5 // see https://legacydocs.hubspot.com/docs/methods/crm-associations/crm-associations-overview
             }, method: Method.Put, convertToPropertiesSchema: true);
-            entity.Associations.AssociatedCompany = new[] { companyId };
+            entity.Associations.AssociatedCompany = [companyId];
             return entity;
         }
 
@@ -244,14 +237,14 @@
         {
             var path = "/crm-associations/v1/associations";
 
-            _client.Execute(path, new
+            client.Execute(path, new
             {
                 fromObjectId = entity.Id,
                 toObjectId = contactId,
                 category = "HUBSPOT_DEFINED",
                 definitionId = 3 // see https://legacydocs.hubspot.com/docs/methods/crm-associations/crm-associations-overview
             }, method: Method.Put, convertToPropertiesSchema: true);
-            entity.Associations.AssociatedContacts = new[] { contactId };
+            entity.Associations.AssociatedContacts = [contactId];
             return entity;
         }
 
@@ -269,7 +262,7 @@
             var companyResults = new List<long>();
             do
             {
-                var companyAssociations = _client.ExecuteList<AssociationIdListHubSpotModel>(string.Format("{0}?limit=100{1}", companyPath, offSet == null ? null : "&offset=" + offSet), convertToPropertiesSchema: false);
+                var companyAssociations = client.ExecuteList<AssociationIdListHubSpotModel>(string.Format("{0}?limit=100{1}", companyPath, offSet == null ? null : "&offset=" + offSet), convertToPropertiesSchema: false);
                 if (companyAssociations.Results.Any())
                     companyResults.AddRange(companyAssociations.Results);
                 if (companyAssociations.HasMore)
@@ -288,7 +281,7 @@
             var contactResults = new List<long>();
             do
             {
-                var contactAssociations = _client.ExecuteList<AssociationIdListHubSpotModel>(string.Format("{0}?limit=100{1}", contactPath, offSet == null ? null : "&offset=" + offSet), convertToPropertiesSchema: false);
+                var contactAssociations = client.ExecuteList<AssociationIdListHubSpotModel>(string.Format("{0}?limit=100{1}", contactPath, offSet == null ? null : "&offset=" + offSet), convertToPropertiesSchema: false);
                 if (contactAssociations.Results.Any())
                     contactResults.AddRange(contactAssociations.Results);
                 if (contactAssociations.HasMore)

--- a/HubSpot.NET/Api/EmailSubscriptions/HubSpotEmailSubcriptionsApi.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/HubSpotEmailSubcriptionsApi.cs
@@ -43,7 +43,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions
         {
             var path = $"{new SubscriptionTypeListHubSpotModel().RouteBasePath}/subscriptions/{email}";
 
-            return _client.Execute<SubscriptionStatusHubSpotModel>(path, Method.GET, false);
+            return _client.Execute<SubscriptionStatusHubSpotModel>(path, Method.Get, false);
         }
 
 
@@ -56,7 +56,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions
         {
             var path = $"{new SubscriptionTypeListHubSpotModel().RouteBasePath}/subscriptions/{email}";
 
-            _client.Execute(path, new { unsubscribeFromAll = true }, Method.PUT, false);
+            _client.Execute(path, new { unsubscribeFromAll = true }, Method.Put, false);
         }
 
         /// <summary>
@@ -71,9 +71,9 @@ namespace HubSpot.NET.Api.EmailSubscriptions
 
             var model = new SubscriptionStatusUpdateHubSpotModel
             {
-                SubscriptionStatuses = new List<SubscriptionStatusDetailHubSpotModel>()
+                SubscriptionStatuses = new()
                 {
-                    new SubscriptionStatusDetailHubSpotModel()
+                    new()
                     {
                         Id = id,
                         Subscribed = false
@@ -81,7 +81,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions
                 }
             };
 
-            _client.Execute(path, model, Method.PUT, false);
+            _client.Execute(path, model, Method.Put, false);
         }
 
 
@@ -112,10 +112,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions
                     subscriptionBasis = basis;
                 }
 
-                if (subscriptionBasisExplanation == null)
-                {
-                    subscriptionBasisExplanation = basisExplanation;
-                }
+                subscriptionBasisExplanation ??= basisExplanation;
 
                 subscription.LegalBasis = subscriptionBasis;
                 subscription.LegalBasisExplanation = subscriptionBasisExplanation;
@@ -123,7 +120,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions
 
             var model = new SubscribeHubSpotModel
             {
-                SubscriptionStatuses = new List<SubscribeStatusHubSpotModel>() { subscription }
+                SubscriptionStatuses = new() { subscription }
             };
             if (setPortalSubscriptionBasis)
             {
@@ -133,7 +130,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions
 
             var path = $"{model.RouteBasePath}/{email}";
 
-            _client.Execute(path, model, Method.PUT, false);
+            _client.Execute(path, model, Method.Put, false);
         }
     }
 }

--- a/HubSpot.NET/Api/EmailSubscriptions/HubSpotEmailSubcriptionsApi.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/HubSpotEmailSubcriptionsApi.cs
@@ -71,14 +71,14 @@ namespace HubSpot.NET.Api.EmailSubscriptions
 
             var model = new SubscriptionStatusUpdateHubSpotModel
             {
-                SubscriptionStatuses = new()
-                {
+                SubscriptionStatuses =
+                [
                     new()
                     {
                         Id = id,
                         Subscribed = false
                     }
-                }
+                ]
             };
 
             _client.Execute(path, model, Method.Put, false);
@@ -120,7 +120,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions
 
             var model = new SubscribeHubSpotModel
             {
-                SubscriptionStatuses = new() { subscription }
+                SubscriptionStatuses = [subscription]
             };
             if (setPortalSubscriptionBasis)
             {

--- a/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
+++ b/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
@@ -8,15 +8,8 @@
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
-    public class HubSpotEngagementApi : IHubSpotEngagementApi
+    public class HubSpotEngagementApi(IHubSpotClient client) : IHubSpotEngagementApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotEngagementApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         /// <summary>
         /// Creates an engagement
         /// </summary>
@@ -25,7 +18,7 @@
         public EngagementHubSpotModel Create(EngagementHubSpotModel entity)
         {
             var path = $"{entity.RouteBasePath}/engagements";
-            var data = _client.Execute<EngagementHubSpotModel>(path, entity, Method.Post, false);
+            var data = client.Execute<EngagementHubSpotModel>(path, entity, Method.Post, false);
             return data;
         }
 
@@ -42,7 +35,7 @@
 
             var path = $"{entity.RouteBasePath}/engagements/{entity.Engagement.Id}";
 
-            _client.Execute(path, entity, Method.Patch, false);
+            client.Execute(path, entity, Method.Patch, false);
         }
 
         /// <summary>
@@ -56,7 +49,7 @@
 
             try
             {
-                var data = _client.Execute<EngagementHubSpotModel>(path, Method.Get, false);
+                var data = client.Execute<EngagementHubSpotModel>(path, Method.Get, false);
                 return data;
             }
             catch (HubSpotException exception)
@@ -83,7 +76,7 @@
                 path = path.SetQueryParam("offset", opts.Offset);
             }
 
-            var data = _client.ExecuteList<EngagementListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: false);
+            var data = client.ExecuteList<EngagementListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: false);
             return data;
         }
 
@@ -102,7 +95,7 @@
                 path = path.SetQueryParam("offset", opts.Offset);
             }
 
-            var data = _client.ExecuteList<EngagementListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: false);
+            var data = client.ExecuteList<EngagementListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: false);
             return data;
         }
 
@@ -114,7 +107,7 @@
         {
             var path = $"{new EngagementHubSpotModel().RouteBasePath}/engagements/{engagementId}";
 
-            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
+            client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -127,7 +120,7 @@
         {
             var path = $"{new EngagementHubSpotModel().RouteBasePath}/engagements/{engagementId}/associations/{objectType}/{objectId}";
 
-            _client.Execute(path, method: Method.Put, convertToPropertiesSchema: true);
+            client.Execute(path, method: Method.Put, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -147,7 +140,7 @@
                 path = path.SetQueryParam("offset", opts.Offset);
             }
 
-            var data = _client.ExecuteList<EngagementListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: false);
+            var data = client.ExecuteList<EngagementListHubSpotModel<T>>(path, opts, convertToPropertiesSchema: false);
             return data;
         }
 

--- a/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
+++ b/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
@@ -25,7 +25,7 @@
         public EngagementHubSpotModel Create(EngagementHubSpotModel entity)
         {
             var path = $"{entity.RouteBasePath}/engagements";
-            var data = _client.Execute<EngagementHubSpotModel>(path, entity, Method.POST, false);
+            var data = _client.Execute<EngagementHubSpotModel>(path, entity, Method.Post, false);
             return data;
         }
 
@@ -42,7 +42,7 @@
 
             var path = $"{entity.RouteBasePath}/engagements/{entity.Engagement.Id}";
 
-            _client.Execute(path, entity, Method.PATCH, false);
+            _client.Execute(path, entity, Method.Patch, false);
         }
 
         /// <summary>
@@ -56,7 +56,7 @@
 
             try
             {
-                var data = _client.Execute<EngagementHubSpotModel>(path, Method.GET, false);
+                var data = _client.Execute<EngagementHubSpotModel>(path, Method.Get, false);
                 return data;
             }
             catch (HubSpotException exception)
@@ -74,10 +74,7 @@
         /// <returns>List of engagements, with additional metadata, e.g. total</returns>
         public EngagementListHubSpotModel<T> List<T>(EngagementListRequestOptions opts = null) where T: EngagementHubSpotModel, new()
         {
-            if (opts == null)
-            {
-                opts = new EngagementListRequestOptions();
-            }
+            opts ??= new();
 
             var path = $"{new EngagementHubSpotModel().RouteBasePath}/engagements/paged".SetQueryParam("limit", opts.Limit);
 
@@ -97,10 +94,7 @@
         /// <returns>List of engagements, with additional metadata, e.g. total</returns>
         public EngagementListHubSpotModel<T> ListRecent<T>(EngagementListRequestOptions opts = null) where T : EngagementHubSpotModel, new()
         {
-            if (opts == null)
-            {
-                opts = new EngagementListRequestOptions();
-            }
+            opts ??= new();
             var path = $"{new EngagementHubSpotModel().RouteBasePath}/engagements/recent/modified".SetQueryParam("count", opts.Limit);
 
             if (opts.Offset.HasValue)
@@ -120,7 +114,7 @@
         {
             var path = $"{new EngagementHubSpotModel().RouteBasePath}/engagements/{engagementId}";
 
-            _client.Execute(path, method: Method.DELETE, convertToPropertiesSchema: true);
+            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -133,7 +127,7 @@
         {
             var path = $"{new EngagementHubSpotModel().RouteBasePath}/engagements/{engagementId}/associations/{objectType}/{objectId}";
 
-            _client.Execute(path, method: Method.PUT, convertToPropertiesSchema: true);
+            _client.Execute(path, method: Method.Put, convertToPropertiesSchema: true);
         }
 
         /// <summary>
@@ -145,10 +139,7 @@
         /// <returns>List of associated engagements</returns>
         public EngagementListHubSpotModel<T> ListAssociated<T>(long objectId, string objectType, EngagementListRequestOptions opts = null) where T: EngagementHubSpotModel, new()
         {
-            if (opts == null)
-            {
-                opts = new EngagementListRequestOptions();
-            }
+            opts ??= new();
             var path = $"{new EngagementHubSpotModel().RouteBasePath}/engagements/associated/{objectType}/{objectId}/paged".SetQueryParam("limit", opts.Limit);
 
             if (opts.Offset.HasValue)

--- a/HubSpot.NET/Api/Files/Dto/FileHubSpotRequestModel.cs
+++ b/HubSpot.NET/Api/Files/Dto/FileHubSpotRequestModel.cs
@@ -85,7 +85,7 @@ namespace HubSpot.NET.Api.Files.Dto
 
             var msg =
                 $"Please enter one of the allowable values: {string.Join(", ", (AllowableValues ?? new string[] {"No allowable values found"}))}.";
-            return new ValidationResult(msg);
+            return new(msg);
         }
     }
 }

--- a/HubSpot.NET/Api/Files/Dto/FileHubSpotRequestModel.cs
+++ b/HubSpot.NET/Api/Files/Dto/FileHubSpotRequestModel.cs
@@ -52,7 +52,7 @@ namespace HubSpot.NET.Api.Files.Dto
     [DataContract]
     public class FileHubSpotRequestOptionsModel
     {
-        [StringRange(AllowableValues = new[] {"PUBLIC_INDEXABLE", "PRIVATE_INDEXABLE", "PRIVATE"},
+        [StringRange(AllowableValues = ["PUBLIC_INDEXABLE", "PRIVATE_INDEXABLE", "PRIVATE"],
             ErrorMessage = "Must be PUBLIC_INDEXABLE, PRIVATE_INDEXABLE, or PRIVATE")]
         [DataMember(Name = "access")]
         public string Access { get; set; } = "PRIVATE";
@@ -63,11 +63,11 @@ namespace HubSpot.NET.Api.Files.Dto
         [DataMember(Name="overwrite")]
         public bool Overwrite { get; set; }
         
-        [StringRange(AllowableValues = new[] { "REJECT", "RETURN_EXISTING", "NONE" }, ErrorMessage = "Must be REJECT, RETURN_EXISTING, or NONE")]
+        [StringRange(AllowableValues = ["REJECT", "RETURN_EXISTING", "NONE"], ErrorMessage = "Must be REJECT, RETURN_EXISTING, or NONE")]
         [DataMember(Name="duplicateValidationStrategy")]
         public string DuplicateValidationStrategy { get; set; }
         
-        [StringRange(AllowableValues = new[] { "ENTIRE_PORTAL", "EXACT_FOLDER" }, ErrorMessage = "Must be ENTIRE_PORTAL or EXACT_FOLDER")]
+        [StringRange(AllowableValues = ["ENTIRE_PORTAL", "EXACT_FOLDER"], ErrorMessage = "Must be ENTIRE_PORTAL or EXACT_FOLDER")]
         [DataMember(Name="duplicateValidationScope")]
         public string DuplicateValidationScope { get; set; }
     }
@@ -84,7 +84,7 @@ namespace HubSpot.NET.Api.Files.Dto
             }
 
             var msg =
-                $"Please enter one of the allowable values: {string.Join(", ", (AllowableValues ?? new string[] {"No allowable values found"}))}.";
+                $"Please enter one of the allowable values: {string.Join(", ", (AllowableValues ?? ["No allowable values found"]))}.";
             return new(msg);
         }
     }

--- a/HubSpot.NET/Api/Files/HubSpotCosFileApi.cs
+++ b/HubSpot.NET/Api/Files/HubSpotCosFileApi.cs
@@ -7,15 +7,8 @@ namespace HubSpot.NET.Api.Files
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
-    public class HubSpotCosFileApi : IHubSpotCosFileApi
+    public class HubSpotCosFileApi(IHubSpotClient client) : IHubSpotCosFileApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotCosFileApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         /// <summary>
         /// Creates a folder within the File Manager
         /// </summary>
@@ -24,7 +17,7 @@ namespace HubSpot.NET.Api.Files
         public FolderHubSpotModel CreateFolder(FolderHubSpotModel folder)
         {
             var path = $"{new FolderHubSpotModel().RouteBasePath}";
-            return _client.Execute<FolderHubSpotModel>(path, folder, Method.Post, false);
+            return client.Execute<FolderHubSpotModel>(path, folder, Method.Post, false);
         }
         
         /// <summary>
@@ -35,7 +28,7 @@ namespace HubSpot.NET.Api.Files
         public FileHubSpotResponseModel UploadFile(FileHubSpotRequestModel entity)
         {
             var path = $"{new FileHubSpotRequestModel().RouteBasePath}/upload";
-            var data = _client.ExecuteMultipart<FileHubSpotResponseModel>(path, entity.File, entity.Name,
+            var data = client.ExecuteMultipart<FileHubSpotResponseModel>(path, entity.File, entity.Name,
                 new()
                 {
                     {"folderPath", entity.FolderPath},

--- a/HubSpot.NET/Api/Files/HubSpotCosFileApi.cs
+++ b/HubSpot.NET/Api/Files/HubSpotCosFileApi.cs
@@ -24,7 +24,7 @@ namespace HubSpot.NET.Api.Files
         public FolderHubSpotModel CreateFolder(FolderHubSpotModel folder)
         {
             var path = $"{new FolderHubSpotModel().RouteBasePath}";
-            return _client.Execute<FolderHubSpotModel>(path, folder, Method.POST, false);
+            return _client.Execute<FolderHubSpotModel>(path, folder, Method.Post, false);
         }
         
         /// <summary>
@@ -36,7 +36,7 @@ namespace HubSpot.NET.Api.Files
         {
             var path = $"{new FileHubSpotRequestModel().RouteBasePath}/upload";
             var data = _client.ExecuteMultipart<FileHubSpotResponseModel>(path, entity.File, entity.Name,
-                new Dictionary<string, string>()
+                new()
                 {
                     {"folderPath", entity.FolderPath},
                     {"folderId", entity.FolderId},

--- a/HubSpot.NET/Api/Note/HubSpotNoteApi.cs
+++ b/HubSpot.NET/Api/Note/HubSpotNoteApi.cs
@@ -25,7 +25,7 @@
         public NoteHubSpotResponseModel Create(NoteHubSpotRequestModel entity)
         {
             var path = $"{entity.RouteBasePath}";
-            var data = _client.Execute<NoteHubSpotResponseModel>(path, entity, Method.POST, false);
+            var data = _client.Execute<NoteHubSpotResponseModel>(path, entity, Method.Post, false);
             return data;
         }
     }

--- a/HubSpot.NET/Api/Note/HubSpotNoteApi.cs
+++ b/HubSpot.NET/Api/Note/HubSpotNoteApi.cs
@@ -8,15 +8,8 @@
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
-    public class HubSpotNoteApi : IHubSpotNoteApi
+    public class HubSpotNoteApi(IHubSpotClient client) : IHubSpotNoteApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotNoteApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         /// <summary>
         /// Creates a note
         /// </summary>
@@ -25,7 +18,7 @@
         public NoteHubSpotResponseModel Create(NoteHubSpotRequestModel entity)
         {
             var path = $"{entity.RouteBasePath}";
-            var data = _client.Execute<NoteHubSpotResponseModel>(path, entity, Method.Post, false);
+            var data = client.Execute<NoteHubSpotResponseModel>(path, entity, Method.Post, false);
             return data;
         }
     }

--- a/HubSpot.NET/Api/Owner/Dto/OwnerListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Owner/Dto/OwnerListHubSpotModel.cs
@@ -12,7 +12,7 @@ namespace HubSpot.NET.Api.Owner.Dto
     [DataContract]
     public class OwnerListHubSpotModel<T> : IHubSpotModel, ICollection<T> where T: OwnerHubSpotModel, new()
     {
-        private List<T> Owners { get; } = new List<T>();
+        private List<T> Owners { get; } = new();
 
         public string RouteBasePath => "/owners/v2";
 

--- a/HubSpot.NET/Api/Owner/Dto/OwnerListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Owner/Dto/OwnerListHubSpotModel.cs
@@ -12,7 +12,7 @@ namespace HubSpot.NET.Api.Owner.Dto
     [DataContract]
     public class OwnerListHubSpotModel<T> : IHubSpotModel, ICollection<T> where T: OwnerHubSpotModel, new()
     {
-        private List<T> Owners { get; } = new();
+        private List<T> Owners { get; } = [];
 
         public string RouteBasePath => "/owners/v2";
 

--- a/HubSpot.NET/Api/Owner/HubSpotOwnerApi.cs
+++ b/HubSpot.NET/Api/Owner/HubSpotOwnerApi.cs
@@ -49,7 +49,7 @@ namespace HubSpot.NET.Api.Owner
 
             try
             {
-                var data = _client.Execute<T>(path, Method.GET, convertToPropertiesSchema: false);
+                var data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: false);
                 return data;
             }
             catch (HubSpotException exception)

--- a/HubSpot.NET/Api/Owner/HubSpotOwnerApi.cs
+++ b/HubSpot.NET/Api/Owner/HubSpotOwnerApi.cs
@@ -8,15 +8,8 @@ using HubSpot.NET.Core.Interfaces;
 namespace HubSpot.NET.Api.Owner
 {
 
-    public class HubSpotOwnerApi : IHubSpotOwnerApi
+    public class HubSpotOwnerApi(IHubSpotClient client) : IHubSpotOwnerApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotOwnerApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         /// <summary>
         /// Gets all owners within your HubSpot account
         /// </summary>
@@ -34,7 +27,7 @@ namespace HubSpot.NET.Api.Owner
                     path = path.SetQueryParam("email", opts.EmailAddress);
             }
 
-            return _client.ExecuteList<OwnerListHubSpotModel<T>>(path, convertToPropertiesSchema: false);
+            return client.ExecuteList<OwnerListHubSpotModel<T>>(path, convertToPropertiesSchema: false);
         }
 
         /// <summary>
@@ -49,7 +42,7 @@ namespace HubSpot.NET.Api.Owner
 
             try
             {
-                var data = _client.Execute<T>(path, Method.Get, convertToPropertiesSchema: false);
+                var data = client.Execute<T>(path, Method.Get, convertToPropertiesSchema: false);
                 return data;
             }
             catch (HubSpotException exception)

--- a/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
@@ -13,7 +13,7 @@ namespace HubSpot.NET.Api.Properties.Dto
     [DataContract]
     public class PropertiesListHubSpotModel<T> : IHubSpotModel, ICollection<T> where T : IHubSpotModel
     {
-        private List<T> Properties { get; } = new List<T>();
+        private List<T> Properties { get; } = new();
 
         public string RouteBasePath
         {

--- a/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Properties/Dto/PropertiesListHubSpotModel.cs
@@ -13,7 +13,7 @@ namespace HubSpot.NET.Api.Properties.Dto
     [DataContract]
     public class PropertiesListHubSpotModel<T> : IHubSpotModel, ICollection<T> where T : IHubSpotModel
     {
-        private List<T> Properties { get; } = new();
+        private List<T> Properties { get; } = [];
 
         public string RouteBasePath
         {

--- a/HubSpot.NET/Api/Properties/HubSpotCompaniesPropertiesApi.cs
+++ b/HubSpot.NET/Api/Properties/HubSpotCompaniesPropertiesApi.cs
@@ -24,21 +24,21 @@ namespace HubSpot.NET.Api.Properties
         {
             var path = $"{new PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>().RouteBasePath}";
 
-            return _client.Execute<CompanyPropertyHubSpotModel>(path, property, Method.POST, convertToPropertiesSchema: false);
+            return _client.Execute<CompanyPropertyHubSpotModel>(path, property, Method.Post, convertToPropertiesSchema: false);
         }
 
         public CompanyPropertyHubSpotModel Update(CompanyPropertyHubSpotModel property)
         {
             var path = $"{new PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>().RouteBasePath}/named/{property.Name}";
 
-            return _client.Execute<CompanyPropertyHubSpotModel>(path, property, Method.PUT, convertToPropertiesSchema: false);
+            return _client.Execute<CompanyPropertyHubSpotModel>(path, property, Method.Put, convertToPropertiesSchema: false);
         }
 
         public void Delete(string propertyName)
         {
             var path = $"{new PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>().RouteBasePath}/named/{propertyName}";
 
-            _client.Execute(path, method: Method.DELETE, convertToPropertiesSchema: true);
+            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
     }
 }

--- a/HubSpot.NET/Api/Properties/HubSpotCompaniesPropertiesApi.cs
+++ b/HubSpot.NET/Api/Properties/HubSpotCompaniesPropertiesApi.cs
@@ -4,41 +4,34 @@ namespace HubSpot.NET.Api.Properties
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
-    public class HubSpotCompaniesPropertiesApi : IHubSpotCompanyPropertiesApi
+    public class HubSpotCompaniesPropertiesApi(IHubSpotClient client) : IHubSpotCompanyPropertiesApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotCompaniesPropertiesApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         public PropertiesListHubSpotModel<CompanyPropertyHubSpotModel> GetAll()
         {
             var path = $"{new PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>().RouteBasePath}";
 
-            return _client.ExecuteList<PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>>(path, convertToPropertiesSchema: false);
+            return client.ExecuteList<PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>>(path, convertToPropertiesSchema: false);
         }
 
         public CompanyPropertyHubSpotModel Create(CompanyPropertyHubSpotModel property)
         {
             var path = $"{new PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>().RouteBasePath}";
 
-            return _client.Execute<CompanyPropertyHubSpotModel>(path, property, Method.Post, convertToPropertiesSchema: false);
+            return client.Execute<CompanyPropertyHubSpotModel>(path, property, Method.Post, convertToPropertiesSchema: false);
         }
 
         public CompanyPropertyHubSpotModel Update(CompanyPropertyHubSpotModel property)
         {
             var path = $"{new PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>().RouteBasePath}/named/{property.Name}";
 
-            return _client.Execute<CompanyPropertyHubSpotModel>(path, property, Method.Put, convertToPropertiesSchema: false);
+            return client.Execute<CompanyPropertyHubSpotModel>(path, property, Method.Put, convertToPropertiesSchema: false);
         }
 
         public void Delete(string propertyName)
         {
             var path = $"{new PropertiesListHubSpotModel<CompanyPropertyHubSpotModel>().RouteBasePath}/named/{propertyName}";
 
-            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
+            client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
     }
 }

--- a/HubSpot.NET/Api/Properties/HubSpotCustomObjectPropertiesApi.cs
+++ b/HubSpot.NET/Api/Properties/HubSpotCustomObjectPropertiesApi.cs
@@ -16,14 +16,14 @@ namespace HubSpot.NET.Api.Properties
         public T GetProperty<T>(string customObjectName, string customObjectProperty) where T : CustomObjectPropertyHubSpotModel, new()
         {
             var path = $"{new PropertiesListHubSpotModel<CustomObjectPropertyHubSpotModel>().RouteBasePath}/{customObjectName}/{customObjectProperty}";
-            var result = _client.Execute<T>(path, null, Method.GET, convertToPropertiesSchema: false);
+            var result = _client.Execute<T>(path, null, Method.Get, convertToPropertiesSchema: false);
             return result;
         }
 
         public T UpdateProperty<T>(string customObjectName, string customObjectProperty, CustomObjectPropertyHubSpotModel property) where T : CustomObjectPropertyHubSpotModel, new()
         {
             var path = $"{new PropertiesListHubSpotModel<CustomObjectPropertyHubSpotModel>().RouteBasePath}/{customObjectName}/{customObjectProperty}";
-            return _client.Execute<T>(path, property, Method.PATCH, convertToPropertiesSchema: false);
+            return _client.Execute<T>(path, property, Method.Patch, convertToPropertiesSchema: false);
         }
     }
 }

--- a/HubSpot.NET/Api/Properties/HubSpotCustomObjectPropertiesApi.cs
+++ b/HubSpot.NET/Api/Properties/HubSpotCustomObjectPropertiesApi.cs
@@ -4,26 +4,19 @@ namespace HubSpot.NET.Api.Properties
     using Core.Interfaces;
     using RestSharp;
 
-    public class HubSpotCustomObjectPropertiesApi : IHubSpotCustomObjectPropertiesApi
+    public class HubSpotCustomObjectPropertiesApi(IHubSpotClient client) : IHubSpotCustomObjectPropertiesApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotCustomObjectPropertiesApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         public T GetProperty<T>(string customObjectName, string customObjectProperty) where T : CustomObjectPropertyHubSpotModel, new()
         {
             var path = $"{new PropertiesListHubSpotModel<CustomObjectPropertyHubSpotModel>().RouteBasePath}/{customObjectName}/{customObjectProperty}";
-            var result = _client.Execute<T>(path, null, Method.Get, convertToPropertiesSchema: false);
+            var result = client.Execute<T>(path, null, Method.Get, convertToPropertiesSchema: false);
             return result;
         }
 
         public T UpdateProperty<T>(string customObjectName, string customObjectProperty, CustomObjectPropertyHubSpotModel property) where T : CustomObjectPropertyHubSpotModel, new()
         {
             var path = $"{new PropertiesListHubSpotModel<CustomObjectPropertyHubSpotModel>().RouteBasePath}/{customObjectName}/{customObjectProperty}";
-            return _client.Execute<T>(path, property, Method.Patch, convertToPropertiesSchema: false);
+            return client.Execute<T>(path, property, Method.Patch, convertToPropertiesSchema: false);
         }
     }
 }

--- a/HubSpot.NET/Api/Schemas/HubSpotSchemaApi.cs
+++ b/HubSpot.NET/Api/Schemas/HubSpotSchemaApi.cs
@@ -141,15 +141,8 @@ namespace HubSpot.NET.Api.Schemas;
         public bool? HasUniqueValue { get; set; }
     }
 
-public class HubSpotSchemaApi : IHubSpotSchemaApi
+public class HubSpotSchemaApi(IHubSpotClient client) : IHubSpotSchemaApi
 {
-    private readonly IHubSpotClient _client;
-
-    public HubSpotSchemaApi(IHubSpotClient client)
-    {
-        _client = client;
-    }
-    
     public SchemaListHubSpotModel<T> List<T>(ListRequestOptions opts = null) where T : SchemaHubSpotModel, new()
     {
         opts ??= new();
@@ -157,7 +150,7 @@ public class HubSpotSchemaApi : IHubSpotSchemaApi
         var path = $"{new SchemaHubSpotModel().RouteBasePath}"
             .SetQueryParam("count", opts.Limit);
 
-        var response = _client.ExecuteList<SchemaListHubSpotModel<T>>(path, convertToPropertiesSchema: false);
+        var response = client.ExecuteList<SchemaListHubSpotModel<T>>(path, convertToPropertiesSchema: false);
         return response;
     }
 }

--- a/HubSpot.NET/Api/Schemas/HubSpotSchemaApi.cs
+++ b/HubSpot.NET/Api/Schemas/HubSpotSchemaApi.cs
@@ -152,7 +152,7 @@ public class HubSpotSchemaApi : IHubSpotSchemaApi
     
     public SchemaListHubSpotModel<T> List<T>(ListRequestOptions opts = null) where T : SchemaHubSpotModel, new()
     {
-        opts ??= new ListRequestOptions();
+        opts ??= new();
 
         var path = $"{new SchemaHubSpotModel().RouteBasePath}"
             .SetQueryParam("count", opts.Limit);

--- a/HubSpot.NET/Api/SearchRequestFilter.cs
+++ b/HubSpot.NET/Api/SearchRequestFilter.cs
@@ -9,14 +9,9 @@ namespace HubSpot.NET.Api
         public string PropertyName { get; set; }
 
         [DataMember(Name = "operator")]
-        public SearchRequestFilterOperatorType Operator { get; set; }
+        public SearchRequestFilterOperatorType Operator { get; set; } = SearchRequestFilterOperatorType.EqualTo;
 
         [DataMember(Name = "value")]
         public string Value { get; set; }
-
-        public SearchRequestFilter()
-        {
-            Operator = SearchRequestFilterOperatorType.EqualTo;
-        }
     }
 }

--- a/HubSpot.NET/Api/Task/HubSpotTaskApi.cs
+++ b/HubSpot.NET/Api/Task/HubSpotTaskApi.cs
@@ -30,7 +30,7 @@ namespace HubSpot.NET.Api.Task
         {
             string path = $"{entity.RouteBasePath}";
 
-            return _client.Execute<T>(path, entity, Method.POST, SerialisationType.PropertyBag);
+            return _client.Execute<T>(path, entity, Method.Post, SerialisationType.PropertyBag);
         }
 
         /// <summary>
@@ -43,15 +43,18 @@ namespace HubSpot.NET.Api.Task
         {
             string path = $"{new T().RouteBasePath}/{taskId}";
 
-            if (propertiesToInclude == null)
-                propertiesToInclude = new List<string> { "hs_task_subject", "hubspot_owner_id", "hs_task_body", "hs_task_status", "hs_task_priority", "hs_task_type", "hs_timestamp" };
+            propertiesToInclude ??= new()
+            {
+                "hs_task_subject", "hubspot_owner_id", "hs_task_body", "hs_task_status", "hs_task_priority", "hs_task_type",
+                "hs_timestamp"
+            };
 
             if (propertiesToInclude.Any())
                 path = path.SetQueryParam("properties", propertiesToInclude);
 
             try
             {
-                return _client.Execute<T>(path, Method.GET, SerialisationType.PropertyBag);
+                return _client.Execute<T>(path, Method.Get, SerialisationType.PropertyBag);
              }
             catch (HubSpotException exception)
             {
@@ -63,8 +66,7 @@ namespace HubSpot.NET.Api.Task
 
         public TaskListHubSpotModel<T> List<T>(ListRequestOptions opts = null) where T: TaskHubSpotModel, new()
         {
-            if (opts == null)
-                opts = new ListRequestOptions();
+            opts ??= new();
 
             string path = $"{new T().RouteBasePath}"
                 .SetQueryParam("count", opts.Limit);
@@ -94,7 +96,7 @@ namespace HubSpot.NET.Api.Task
             long entityId = entity.Id.Value;
             string path = $"{entity.RouteBasePath}/{entity.Id}";
 
-            T data = _client.Execute<T>(path, entity, Method.PATCH, SerialisationType.PropertyBag);
+            T data = _client.Execute<T>(path, entity, Method.Patch, SerialisationType.PropertyBag);
             // this just undoes some dirty meddling
             entity.Id = entityId;
 
@@ -109,7 +111,7 @@ namespace HubSpot.NET.Api.Task
         {
             var path = $"{new TaskHubSpotModel().RouteBasePath}/{taskId}";
 
-            _client.Execute(path, method: Method.DELETE, convertToPropertiesSchema: true);
+            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
     }
 }

--- a/HubSpot.NET/Api/Task/HubSpotTaskApi.cs
+++ b/HubSpot.NET/Api/Task/HubSpotTaskApi.cs
@@ -10,15 +10,8 @@ namespace HubSpot.NET.Api.Task
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
-    public class HubSpotTaskApi : IHubSpotTaskApi
+    public class HubSpotTaskApi(IHubSpotClient client) : IHubSpotTaskApi
     {
-        private readonly IHubSpotClient _client;
-
-        public HubSpotTaskApi(IHubSpotClient client)
-        {
-            _client = client;
-        }
-
         /// <summary>
         /// Creates a Task entity
         /// </summary>
@@ -30,7 +23,7 @@ namespace HubSpot.NET.Api.Task
         {
             string path = $"{entity.RouteBasePath}";
 
-            return _client.Execute<T>(path, entity, Method.Post, SerialisationType.PropertyBag);
+            return client.Execute<T>(path, entity, Method.Post, SerialisationType.PropertyBag);
         }
 
         /// <summary>
@@ -43,18 +36,19 @@ namespace HubSpot.NET.Api.Task
         {
             string path = $"{new T().RouteBasePath}/{taskId}";
 
-            propertiesToInclude ??= new()
-            {
-                "hs_task_subject", "hubspot_owner_id", "hs_task_body", "hs_task_status", "hs_task_priority", "hs_task_type",
+            propertiesToInclude ??=
+            [
+                "hs_task_subject", "hubspot_owner_id", "hs_task_body", "hs_task_status", "hs_task_priority",
+                "hs_task_type",
                 "hs_timestamp"
-            };
+            ];
 
             if (propertiesToInclude.Any())
                 path = path.SetQueryParam("properties", propertiesToInclude);
 
             try
             {
-                return _client.Execute<T>(path, Method.Get, SerialisationType.PropertyBag);
+                return client.Execute<T>(path, Method.Get, SerialisationType.PropertyBag);
              }
             catch (HubSpotException exception)
             {
@@ -77,7 +71,7 @@ namespace HubSpot.NET.Api.Task
             if (opts.Offset.HasValue)
                 path = path.SetQueryParam("after", opts.Offset);
 
-            TaskListHubSpotModel<T> data = _client.ExecuteList<TaskListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
+            TaskListHubSpotModel<T> data = client.ExecuteList<TaskListHubSpotModel<T>>(path, convertToPropertiesSchema: true);
 
             return data;
         }
@@ -96,7 +90,7 @@ namespace HubSpot.NET.Api.Task
             long entityId = entity.Id.Value;
             string path = $"{entity.RouteBasePath}/{entity.Id}";
 
-            T data = _client.Execute<T>(path, entity, Method.Patch, SerialisationType.PropertyBag);
+            T data = client.Execute<T>(path, entity, Method.Patch, SerialisationType.PropertyBag);
             // this just undoes some dirty meddling
             entity.Id = entityId;
 
@@ -111,7 +105,7 @@ namespace HubSpot.NET.Api.Task
         {
             var path = $"{new TaskHubSpotModel().RouteBasePath}/{taskId}";
 
-            _client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
+            client.Execute(path, method: Method.Delete, convertToPropertiesSchema: true);
         }
     }
 }

--- a/HubSpot.NET/Core/HubSpotApi.cs
+++ b/HubSpot.NET/Core/HubSpotApi.cs
@@ -13,6 +13,7 @@ using HubSpot.NET.Api.Properties;
 using HubSpot.NET.Api.Schemas;
 using HubSpot.NET.Core.Interfaces;
 using HubSpot.NET.Core.OAuth.Dto;
+using System;
 
 namespace HubSpot.NET.Core
 {
@@ -73,9 +74,23 @@ namespace HubSpot.NET.Core
             Initialise(client);
         }
 
+        public HubSpotApi(string apiKey, int ratePermitLimit, int rateQueueLimit, TimeSpan rateWindow)
+        {
+            IHubSpotClient client = new HubSpotBaseClient(apiKey, ratePermitLimit, rateQueueLimit, rateWindow);
+
+            Initialise(client);
+        }
+
         public HubSpotApi(HubSpotToken token)
         {
             IHubSpotClient client = new HubSpotBaseClient(token);
+
+            Initialise(client);
+        }
+
+        public HubSpotApi(HubSpotToken token, int ratePermitLimit, int rateQueueLimit, TimeSpan rateWindow)
+        {
+            IHubSpotClient client = new HubSpotBaseClient(token, ratePermitLimit, rateQueueLimit, rateWindow);
 
             Initialise(client);
         }

--- a/HubSpot.NET/Core/HubSpotBaseClient.cs
+++ b/HubSpot.NET/Core/HubSpotBaseClient.cs
@@ -206,7 +206,6 @@ namespace HubSpot.NET.Core
                     break;
             }
 
-            //request.JsonSerializer = new NewtonsoftRestSharpSerializer();
             return request;
         }
 

--- a/HubSpot.NET/Core/HubSpotBaseClient.cs
+++ b/HubSpot.NET/Core/HubSpotBaseClient.cs
@@ -11,7 +11,7 @@ namespace HubSpot.NET.Core
 {
     public sealed class HubSpotBaseClient : IHubSpotClient
     {
-        private readonly RequestSerializer _serializer = new RequestSerializer(new RequestDataConverter());
+        private readonly RequestSerializer _serializer = new(new());
         private RestClient _client;
 
         public static string BaseUrl { get => "https://api.hubapi.com"; }
@@ -27,7 +27,7 @@ namespace HubSpot.NET.Core
 
         private void Initialise()
         {
-            _client = new RestClient(BaseUrl);
+            _client = new(BaseUrl);
         }
 
         /// <summary>
@@ -50,13 +50,13 @@ namespace HubSpot.NET.Core
             Initialise();
         }
 
-        public T Execute<T>(string absoluteUriPath, object entity = null, Method method = Method.GET, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new()
+        public T Execute<T>(string absoluteUriPath, object entity = null, Method method = Method.Get, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new()
         {
             return Execute<T>(absoluteUriPath, entity, method, convertToPropertiesSchema ? SerialisationType.PropertiesSchema : SerialisationType.Raw);
         }
-        public T Execute<T>(string absoluteUriPath, object entity = null, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new()
+        public T Execute<T>(string absoluteUriPath, object entity = null, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new()
         {
-            string json = (method == Method.GET || entity == null)
+            string json = (method == Method.Get || entity == null)
                 ? null
                 : _serializer.SerializeEntity(entity, serialisationType);
 
@@ -65,50 +65,50 @@ namespace HubSpot.NET.Core
             return data;
         }
 
-        public T Execute<T>(string absoluteUriPath, Method method = Method.GET, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new()
+        public T Execute<T>(string absoluteUriPath, Method method = Method.Get, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new()
         {
             return Execute<T>(absoluteUriPath, method, convertToPropertiesSchema ? SerialisationType.PropertiesSchema : SerialisationType.Raw);
 
         }
-        public T Execute<T>(string absoluteUriPath, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new()
+        public T Execute<T>(string absoluteUriPath, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new()
         {
             T data = SendRequest(absoluteUriPath, method, null, responseData => (T)_serializer.DeserializeEntity<T>(responseData, serialisationType != SerialisationType.Raw));
 
             return data;
         }
 
-        public void Execute(string absoluteUriPath, object entity = null, Method method = Method.GET, bool convertToPropertiesSchema = true)
+        public void Execute(string absoluteUriPath, object entity = null, Method method = Method.Get, bool convertToPropertiesSchema = true)
         {
             Execute(absoluteUriPath, entity, method, convertToPropertiesSchema ? SerialisationType.PropertiesSchema : SerialisationType.Raw);
         }
-        public void Execute(string absoluteUriPath, object entity = null, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag)
+        public void Execute(string absoluteUriPath, object entity = null, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag)
         {
-            string json = (method == Method.GET || entity == null)
+            string json = (method == Method.Get || entity == null)
                 ? null
                 : _serializer.SerializeEntity(entity, serialisationType);
 
             SendRequest(absoluteUriPath, method, json);
         }
 
-        public void ExecuteBatch(string absoluteUriPath, List<object> entities, Method method = Method.GET, bool convertToPropertiesSchema = true)
+        public void ExecuteBatch(string absoluteUriPath, List<object> entities, Method method = Method.Get, bool convertToPropertiesSchema = true)
         {
             ExecuteBatch(absoluteUriPath, entities, method, convertToPropertiesSchema ? SerialisationType.PropertiesSchema : SerialisationType.Raw);
         }
-        public void ExecuteBatch(string absoluteUriPath, List<object> entities, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag)
+        public void ExecuteBatch(string absoluteUriPath, List<object> entities, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag)
         {
-            string json = (method == Method.GET || entities == null)
+            string json = (method == Method.Get || entities == null)
                 ? null
                 : _serializer.SerializeEntity(entities, serialisationType);
 
             SendRequest(absoluteUriPath, method, json);
         }
 
-        public T ExecuteMultipart<T>(string absoluteUriPath, byte[] data, string filename, Dictionary<string,string> parameters, Method method = Method.POST) where T : new()
+        public T ExecuteMultipart<T>(string absoluteUriPath, byte[] data, string filename, Dictionary<string,string> parameters, Method method = Method.Post) where T : new()
         {
             string path = $"{BaseUrl}{absoluteUriPath}";
-            IRestRequest request = ConfigureRequestAuthentication(path, method, null);
+            RestRequest request = ConfigureRequestAuthentication(path, method, null);
 
-            request.AddFileBytes("file", data, filename);
+            request.AddFile("file", data, filename);
 
             foreach (KeyValuePair<string, string> kvp in parameters)
             {
@@ -121,23 +121,23 @@ namespace HubSpot.NET.Core
             }
                
 
-            IRestResponse<T> response = _client.Execute<T>(request);
+            RestResponse<T> response = _client.Execute<T>(request);
 
             T responseData = response.Data;
 
-            if (!response.IsSuccessful())
+            if (!response.IsSuccessful)
                 throw new HubSpotException("Error from HubSpot", new HubSpotError(response.StatusCode, response.StatusDescription));
 
             return responseData;
         }
 
-        public T ExecuteList<T>(string absoluteUriPath, object entity = null, Method method = Method.GET, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new()
+        public T ExecuteList<T>(string absoluteUriPath, object entity = null, Method method = Method.Get, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new()
         {
             return ExecuteList<T>(absoluteUriPath, entity, method, convertToPropertiesSchema ? SerialisationType.PropertiesSchema : SerialisationType.Raw);
         }
-        public T ExecuteList<T>(string absoluteUriPath, object entity = null, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new()
+        public T ExecuteList<T>(string absoluteUriPath, object entity = null, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new()
         {
-            string json = (method == Method.GET || entity == null)
+            string json = (method == Method.Get || entity == null)
                 ? null
                 : _serializer.SerializeEntity(entity, true);
 
@@ -161,17 +161,17 @@ namespace HubSpot.NET.Core
 
         private string SendRequest(string path, Method method, string json)
         {
-            IRestRequest request = ConfigureRequestAuthentication(path, method);
+            RestRequest request = ConfigureRequestAuthentication(path, method);
 
-            if (method != Method.GET && !string.IsNullOrWhiteSpace(json))
+            if (method != Method.Get && !string.IsNullOrWhiteSpace(json))
                 request.AddParameter("application/json", json, ParameterType.RequestBody);
 
-            IRestResponse response = _client.Execute(request);
+            RestResponse response = _client.Execute(request);
 
             string responseData = response.Content;
 
-            if (!response.IsSuccessful())
-                throw new HubSpotException("Error from HubSpot", new HubSpotError(response.StatusCode, response.StatusDescription), responseData);
+            if (!response.IsSuccessful)
+                throw new HubSpotException("Error from HubSpot", new(response.StatusCode, response.StatusDescription), responseData);
 
             return responseData;
         }
@@ -185,7 +185,7 @@ namespace HubSpot.NET.Core
             RestRequest request = new RestRequest(path, method);
             request.RequestFormat = DataFormat.Json;
 #else
-            RestRequest request = new RestRequest(path, method, DataFormat.Json);
+            RestRequest request = new(path, method);
 #endif
             switch (_mode)
             {
@@ -206,7 +206,7 @@ namespace HubSpot.NET.Core
                     break;
             }
 
-            request.JsonSerializer = new NewtonsoftRestSharpSerializer();
+            //request.JsonSerializer = new NewtonsoftRestSharpSerializer();
             return request;
         }
 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -1,7 +1,10 @@
+using HubSpot.NET.Api.Associations.Dto;
+
 namespace HubSpot.NET.Core.Interfaces;
 
 public interface IHubSpotAssociationsApi
 {
+    AssociationListHubSpotModel List(string objectType, string objectId, string toObjectType);
     void AssociationToObject(string objectType, string objectId, string toObjectType, string toObjectId);
 
     void AssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId,

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -4,6 +4,7 @@ namespace HubSpot.NET.Core.Interfaces;
 
 public interface IHubSpotAssociationsApi
 {
+    AssociationTypeListHubSpotModel ListTypes(string fromObjectType, string toObjectType);
     AssociationListHubSpotModel List(string objectType, string objectId, string toObjectType);
     void AssociationToObject(string objectType, string objectId, string toObjectType, string toObjectId);
 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -38,10 +38,9 @@ public interface IHubSpotAssociationsApi
     /// <param name="objectId"> the ID of the record to associate.</param>
     /// <param name="toObjectType"> the ID of the record to associate.</param>
     /// <param name="toObjectId"> the ID of the record to associate.</param>
-    /// <param name="associationCategory">Category type: HUBSPOT_DEFINED, INTEGRATOR_DEFINED, USER_DEFINED</param>
-    /// <param name="associationTypeId">This is the ID of the label, can be hard to find, the url of the label in your settings is a good place to look</param>
-    void AssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId,
-        string associationCategory, int associationTypeId);
+    /// <param name="associationTypes">a list of association types to add</param>
+    public void AssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId,
+        AssociationType[] associationTypes);
 
     /// <summary>
     /// Deletes an association between 2 objects

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -4,10 +4,63 @@ namespace HubSpot.NET.Core.Interfaces;
 
 public interface IHubSpotAssociationsApi
 {
+    /// <summary>
+    /// Gets association types between 2 object types
+    /// </summary>
+    /// <param name="fromObjectType">the type of the object you're fetching associations (e.g. contact) from.</param>
+    /// <param name="toObjectType"> the type of the object you are fetching associations to.</param>
     AssociationTypeListHubSpotModel ListTypes(string fromObjectType, string toObjectType);
+
+    /// <summary>
+    /// Gets associations to a specific object type
+    /// </summary>
+    /// <param name="objectType">the type of the object you're fetching associations (e.g. contact).</param>
+    /// <param name="objectId"> the ID of the record to find associations for.</param>
+    /// <param name="toObjectType"> the type of the object you are fetching associations for.</param>
     AssociationListHubSpotModel List(string objectType, string objectId, string toObjectType);
+
+    /// <summary>
+    /// Adds the ability to associate via the default association
+    /// See the PUT documentation here: https://developers.hubspot.com/docs/api/crm/associations
+    /// </summary>
+    /// <param name="objectType">the type of the object you're associating (e.g. contact).</param>
+    /// <param name="objectId"> the ID of the record to associate.</param>
+    /// <param name="toObjectType"> the ID of the record to associate.</param>
+    /// <param name="toObjectId"> the ID of the record to associate.</param>
     void AssociationToObject(string objectType, string objectId, string toObjectType, string toObjectId);
 
+    /// <summary>
+    /// Adds the ability to associate via the label
+    /// See the PUT documentation here: https://developers.hubspot.com/docs/api/crm/associations.
+    /// Important - this will overwrite existing associations between the objects - see https://developers.hubspot.com/docs/guides/api/crm/associations/associations-v4#update-record-association-labels
+    /// </summary>
+    /// <param name="objectType">the type of the object you're associating (e.g. contact).</param>
+    /// <param name="objectId"> the ID of the record to associate.</param>
+    /// <param name="toObjectType"> the ID of the record to associate.</param>
+    /// <param name="toObjectId"> the ID of the record to associate.</param>
+    /// <param name="associationCategory">Category type: HUBSPOT_DEFINED, INTEGRATOR_DEFINED, USER_DEFINED</param>
+    /// <param name="associationTypeId">This is the ID of the label, can be hard to find, the url of the label in your settings is a good place to look</param>
     void AssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId,
         string associationCategory, int associationTypeId);
+
+    /// <summary>
+    /// Deletes an association between 2 objects
+    /// See the DELETE documentation here: https://developers.hubspot.com/docs/guides/api/crm/associations/associations-v4#remove-record-associations
+    /// </summary>
+    /// <param name="objectType">the type of the object that is associated from (e.g. contact).</param>
+    /// <param name="objectId"> the ID of the record that is associated from.</param>
+    /// <param name="toObjectType"> the type of the object that is associated to.</param>
+    /// <param name="toObjectId"> the ID of the record that is associated to.</param>
+    void DeleteAssociationToObject(string objectType, string objectId, string toObjectType, string toObjectId);
+
+    /// <summary>
+    /// Deletes a specific label for an association leaving the association itself including other labels when applicable 
+    /// See the PUT documentation here: https://developers.hubspot.com/docs/guides/api/crm/associations/associations-v4#remove-record-associations
+    /// </summary>
+    /// <param name="objectType">the type of the object that is associated from (e.g. contact).</param>
+    /// <param name="objectId"> the ID of the record that is associated from.</param>
+    /// <param name="toObjectType"> the type of the object that is associated to.</param>
+    /// <param name="toObjectId"> the ID of the record that is associated to.</param>
+    /// <param name="associations">A tuple with all the associationTypes that are to be removed</param>
+    void DeleteAssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId, (string associationCategory, int associationTypeId)[] associations);
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotClient.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotClient.cs
@@ -6,22 +6,22 @@ namespace HubSpot.NET.Core.Interfaces
 {
     public interface IHubSpotClient
     {
-        T Execute<T>(string absoluteUriPath, object entity = null, Method method = Method.GET, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new();
-        T Execute<T>(string absoluteUriPath, object entity = null, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new();
+        T Execute<T>(string absoluteUriPath, object entity = null, Method method = Method.Get, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new();
+        T Execute<T>(string absoluteUriPath, object entity = null, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new();
 
-        T Execute<T>(string absoluteUriPath, Method method = Method.GET, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new();
-        T Execute<T>(string absoluteUriPath, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new();
+        T Execute<T>(string absoluteUriPath, Method method = Method.Get, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new();
+        T Execute<T>(string absoluteUriPath, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new();
 
-        void Execute(string absoluteUriPath, object entity = null, Method method = Method.GET, bool convertToPropertiesSchema = true);
-        void Execute(string absoluteUriPath, object entity = null, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag);
+        void Execute(string absoluteUriPath, object entity = null, Method method = Method.Get, bool convertToPropertiesSchema = true);
+        void Execute(string absoluteUriPath, object entity = null, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag);
 
-        void ExecuteBatch(string absoluteUriPath, List<object> entities, Method method = Method.GET, bool convertToPropertiesSchema = true);
-        void ExecuteBatch(string absoluteUriPath, List<object> entities, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag);
+        void ExecuteBatch(string absoluteUriPath, List<object> entities, Method method = Method.Get, bool convertToPropertiesSchema = true);
+        void ExecuteBatch(string absoluteUriPath, List<object> entities, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag);
 
-        T ExecuteMultipart<T>(string absoluteUriPath, byte[] data, string filename, Dictionary<string,string> parameters, Method method = Method.POST) where T : new();
+        T ExecuteMultipart<T>(string absoluteUriPath, byte[] data, string filename, Dictionary<string,string> parameters, Method method = Method.Post) where T : new();
 
-        T ExecuteList<T>(string absoluteUriPath, object entity = null, Method method = Method.GET, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new();
-        T ExecuteList<T>(string absoluteUriPath, object entity = null, Method method = Method.GET, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new();
+        T ExecuteList<T>(string absoluteUriPath, object entity = null, Method method = Method.Get, bool convertToPropertiesSchema = true) where T : IHubSpotModel, new();
+        T ExecuteList<T>(string absoluteUriPath, object entity = null, Method method = Method.Get, SerialisationType serialisationType = SerialisationType.PropertyBag) where T : IHubSpotModel, new();
 
         void UpdateToken(HubSpotToken token);
     }

--- a/HubSpot.NET/Core/ListRequestOptions.cs
+++ b/HubSpot.NET/Core/ListRequestOptions.cs
@@ -61,6 +61,6 @@ namespace HubSpot.NET.Core
         /// </remarks>
         public virtual long? Offset { get; set; } = null;
 
-        public virtual List<string> PropertiesToInclude { get; set; } = new List<string>();
+        public virtual List<string> PropertiesToInclude { get; set; } = new();
     }
 }

--- a/HubSpot.NET/Core/ListRequestOptions.cs
+++ b/HubSpot.NET/Core/ListRequestOptions.cs
@@ -61,6 +61,6 @@ namespace HubSpot.NET.Core
         /// </remarks>
         public virtual long? Offset { get; set; } = null;
 
-        public virtual List<string> PropertiesToInclude { get; set; } = new();
+        public virtual List<string> PropertiesToInclude { get; set; } = [];
     }
 }

--- a/HubSpot.NET/Core/OAuth/Dto/HubSpotToken.cs
+++ b/HubSpot.NET/Core/OAuth/Dto/HubSpotToken.cs
@@ -16,11 +16,6 @@
         public int ExpiresIn { get; set; }
 
         [JsonIgnore]
-        public DateTimeOffset Created { get; private set; }
-
-        public HubSpotToken()
-        {
-            Created = DateTimeOffset.Now;
-        }
+        public DateTimeOffset Created { get; private set; } = DateTimeOffset.Now;
     }
 }

--- a/HubSpot.NET/Core/OAuth/Dto/RequestRefreshTokenHubSpotModel.cs
+++ b/HubSpot.NET/Core/OAuth/Dto/RequestRefreshTokenHubSpotModel.cs
@@ -6,7 +6,7 @@
     public class RequestRefreshTokenHubSpotModel
     {
         [DataMember(Name = "grant_type")]
-        public string GrantType { get; set; }
+        public string GrantType { get; set; } = "refresh_token";
 
         [DataMember(Name = "client_id")]
         public string ClientId { get; set; }
@@ -19,11 +19,5 @@
 
         [DataMember(Name = "refresh_token")]
         public string RefreshToken { get; set; }
-
-
-        public RequestRefreshTokenHubSpotModel()
-        {
-            GrantType = "refresh_token";
-        }
     }
 }

--- a/HubSpot.NET/Core/OAuth/Dto/RequestTokenHubSpotModel.cs
+++ b/HubSpot.NET/Core/OAuth/Dto/RequestTokenHubSpotModel.cs
@@ -6,7 +6,7 @@
     public class RequestTokenHubSpotModel
     {
         [DataMember(Name = "grant_type")]
-        public string GrantType { get; set; }
+        public string GrantType { get; set; } = "authorization_code";
 
         [DataMember(Name = "client_id")]
         public string ClientId { get; set; }
@@ -19,10 +19,5 @@
 
         [DataMember(Name = "code")]
         public string Code { get; set; }
-
-        public RequestTokenHubSpotModel()
-        {
-            GrantType = "authorization_code";
-        }
     }
 }

--- a/HubSpot.NET/Core/OAuth/FakeSerializer.cs
+++ b/HubSpot.NET/Core/OAuth/FakeSerializer.cs
@@ -1,4 +1,6 @@
-﻿namespace HubSpot.NET.Core.OAuth
+﻿using RestSharp;
+
+namespace HubSpot.NET.Core.OAuth
 {
 	using RestSharp.Serializers;
 
@@ -7,11 +9,11 @@
         public string RootElement { get; set; }
         public string Namespace { get; set; }
         public string DateFormat { get; set; }
-        public string ContentType { get; set; }
+        public ContentType ContentType { get; set; }
 
         internal FakeSerializer()
         {
-            ContentType = "application/x-www-form-urlencoded";
+            ContentType = ContentType.FormUrlEncoded;
         }
         public string Serialize(object obj)
         {

--- a/HubSpot.NET/Core/OAuth/HubSpotOAuthApi.cs
+++ b/HubSpot.NET/Core/OAuth/HubSpotOAuthApi.cs
@@ -89,10 +89,7 @@
                     builder.Append($"%20{OAuthScopeNameConversions[scope]}");
             }
 
-            RestRequest request = new(MidRoute)
-            {
-                //JsonSerializer = new FakeSerializer()
-            };
+            RestRequest request = new(MidRoute);
 
             Dictionary<string, string> jsonPreStringPairs = JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(model));
 

--- a/HubSpot.NET/Core/OAuth/HubSpotOAuthApi.cs
+++ b/HubSpot.NET/Core/OAuth/HubSpotOAuthApi.cs
@@ -8,11 +8,10 @@
 	using Newtonsoft.Json;
 	using RestSharp;
 
-	public class HubSpotOAuthApi
+	public class HubSpotOAuthApi(string basePath, string clientId, string clientSecret)
     {
-        public string ClientId { get; protected set; }
-        private string _clientSecret;
-        private readonly string _basePath;
+        public string ClientId { get; protected set; } = clientId;
+        private string _clientSecret = clientSecret;
 
         public virtual string MidRoute => "oauth/v1/token";
 
@@ -35,13 +34,6 @@
         };
 
 
-        public HubSpotOAuthApi(string basePath, string clientId, string clientSecret)
-        {
-            _basePath = basePath;
-            ClientId = clientId;
-            _clientSecret = clientSecret;
-        }
-
         public HubSpotToken Authorize(string authCode, string redirectUri)
         {
             RequestTokenHubSpotModel model = new()
@@ -52,7 +44,7 @@
                 RedirectUri = redirectUri
             };
 
-            HubSpotToken token = InitiateRequest(model, _basePath);
+            HubSpotToken token = InitiateRequest(model, basePath);
             return token;
         }
 
@@ -66,7 +58,7 @@
                 RefreshToken = token.RefreshToken
             };
 
-            HubSpotToken refreshToken = InitiateRequest(model, _basePath);
+            HubSpotToken refreshToken = InitiateRequest(model, basePath);
             return refreshToken;
         }
 

--- a/HubSpot.NET/Core/OAuth/HubSpotOAuthApi.cs
+++ b/HubSpot.NET/Core/OAuth/HubSpotOAuthApi.cs
@@ -16,7 +16,7 @@
 
         public virtual string MidRoute => "oauth/v1/token";
 
-        private readonly Dictionary<OAuthScopes, string> OAuthScopeNameConversions = new Dictionary<OAuthScopes, string>
+        private readonly Dictionary<OAuthScopes, string> OAuthScopeNameConversions = new()
         {
             { OAuthScopes.Automation , "automation" },
             { OAuthScopes.BusinessIntelligence, "business-intelligence" },
@@ -44,7 +44,7 @@
 
         public HubSpotToken Authorize(string authCode, string redirectUri)
         {
-            RequestTokenHubSpotModel model = new RequestTokenHubSpotModel()
+            RequestTokenHubSpotModel model = new()
             {
                 ClientId = ClientId,
                 ClientSecret = _clientSecret,
@@ -58,7 +58,7 @@
 
         public HubSpotToken Refresh(string redirectUri, HubSpotToken token)
         {
-            RequestRefreshTokenHubSpotModel model = new RequestRefreshTokenHubSpotModel()
+            RequestRefreshTokenHubSpotModel model = new()
             {
                 ClientId = ClientId,
                 ClientSecret = _clientSecret,
@@ -78,9 +78,9 @@
 
         private HubSpotToken InitiateRequest<K>(K model, string basePath, params OAuthScopes[] scopes)
         {
-            RestClient client = new RestClient(basePath);
+            RestClient client = new(basePath);
 
-            StringBuilder builder = new StringBuilder();
+            StringBuilder builder = new();
             foreach (OAuthScopes scope in scopes)
             {
                 if (builder.Length == 0)
@@ -89,18 +89,18 @@
                     builder.Append($"%20{OAuthScopeNameConversions[scope]}");
             }
 
-            RestRequest request = new RestRequest(MidRoute)
+            RestRequest request = new(MidRoute)
             {
-                JsonSerializer = new FakeSerializer()
+                //JsonSerializer = new FakeSerializer()
             };
 
             Dictionary<string, string> jsonPreStringPairs = JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(model));
 
-            StringBuilder bodyBuilder = new StringBuilder();
+            StringBuilder bodyBuilder = new();
             foreach(KeyValuePair<string,string> pair in jsonPreStringPairs)
             {
                 if (bodyBuilder.Length > 0)
-                    bodyBuilder.Append("&");
+                    bodyBuilder.Append('&');
 
                 bodyBuilder.Append($"{pair.Key}={pair.Value}");
             }
@@ -111,7 +111,7 @@
             if (builder.Length > 0)
                 request.AddQueryParameter("scope", builder.ToString());
 
-            IRestResponse<HubSpotToken> serverReponse = client.Post<HubSpotToken>(request);
+            var serverReponse = client.ExecutePost<HubSpotToken>(request);
 
             if (serverReponse.ResponseStatus != ResponseStatus.Completed)
                 throw new HubSpotException("Server did not respond to authorization request. Content: " + serverReponse.Content, new HubSpotError(serverReponse.StatusCode, serverReponse.Content), serverReponse.Content);

--- a/HubSpot.NET/Core/Requests/JsonContent.cs
+++ b/HubSpot.NET/Core/Requests/JsonContent.cs
@@ -3,13 +3,9 @@ using System.Text;
 
 namespace HubSpot.NET.Core.Requests
 {
-    public class JsonContent : StringContent
+    public class JsonContent(string json, Encoding encoding) : StringContent(json, encoding, "application/json")
     {
         public JsonContent(string json) : this(json, Encoding.UTF8)
-        {
-        }
-
-        public JsonContent(string json, Encoding encoding) : base(json, encoding, "application/json")
         {
         }
     }

--- a/HubSpot.NET/Core/Requests/RequestDataConverter.cs
+++ b/HubSpot.NET/Core/Requests/RequestDataConverter.cs
@@ -136,7 +136,7 @@ namespace HubSpot.NET.Core.Requests
                 var expandoEntry = entry as ExpandoObject;
                 var dto = ConvertSingleEntity(expandoEntry, Activator.CreateInstance(genericEntityType));
                 // add entity to list
-                listAddMethod.Invoke(listInstance, new[] { dto });
+                listAddMethod.Invoke(listInstance, [dto]);
             }
             // assign our reflected list instance onto the data object
             dataTargetProp.SetValue(data, listInstance);

--- a/HubSpot.NET/Core/Requests/RequestSerializer.cs
+++ b/HubSpot.NET/Core/Requests/RequestSerializer.cs
@@ -19,7 +19,7 @@ namespace HubSpot.NET.Core.Requests
         /// </summary> 
         protected RequestSerializer()
         {
-            _jsonSerializerSettings = new JsonSerializerSettings
+            _jsonSerializerSettings = new()
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 Converters = new List<JsonConverter> { new StringEnumConverter() },

--- a/HubSpot.NET/Core/RestSharpExtensions.cs
+++ b/HubSpot.NET/Core/RestSharpExtensions.cs
@@ -9,7 +9,7 @@ namespace HubSpot.NET.Core
 {
     public static class RestSharpExtensions
     {
-        public static bool IsSuccessful(this IRestResponse response)
+        public static bool IsSuccessful(this RestResponse response)
         {
             return (int) response.StatusCode >= 200 
                    && (int) response.StatusCode <= 299 

--- a/HubSpot.NET/Core/Serializers/NewtonsoftRestSharpSerializer.cs
+++ b/HubSpot.NET/Core/Serializers/NewtonsoftRestSharpSerializer.cs
@@ -5,7 +5,8 @@
     using Newtonsoft.Json;
 	using Newtonsoft.Json.Converters;
 	using Newtonsoft.Json.Serialization;
-	using RestSharp.Serializers;
+    using RestSharp;
+    using RestSharp.Serializers;
 
 	public class NewtonsoftRestSharpSerializer : ISerializer
     {
@@ -18,11 +19,6 @@
                 Converters = new List<JsonConverter> { new StringEnumConverter() },
                 NullValueHandling = NullValueHandling.Ignore
             });
-        }
-
-        public NewtonsoftRestSharpSerializer()
-        {
-            ContentType = "application/json";
         }
 
         /// <summary>
@@ -43,6 +39,6 @@
         /// <summary>
         /// Content type for serialized content
         /// </summary>
-        public string ContentType { get; set; }
+        public ContentType ContentType { get; set; } = ContentType.Json;
     }
 }

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -12,14 +12,11 @@
     <PackageTags>hubspot api wrapper c# contact company deal engagement properties crm custom objects</PackageTags>
     <PackageReleaseNotes>1.0.0</PackageReleaseNotes>
     <PackageId>HubSpot.NETCORE</PackageId>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageVersion>1.0.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -16,8 +16,8 @@
     <PackageVersion>1.0.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="RestSharp" Version="106.6.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -18,5 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
The code referenced old versions of RestSharp & NewtonSoft with a lot of vulnerabilities.
I updated this and made the necessary changes to make this work.  Also upgraded from .Net 6 to .Net 8.
Fixed some issues with the custom objects api.
Lastly I ran it through ReSharper to improve code and readability. 

EDIT:
Also added a method to get associations for a specific object [using this api](https://developers.hubspot.com/docs/reference/api/crm/associations/association-details#get-%2Fcrm%2Fv4%2Fobjects%2F%7Bobjecttype%7D%2F%7Bobjectid%7D%2Fassociations%2F%7Btoobjecttype%7D)
And added the possibility to have a rate limiter for making sure you don't exhaust the [HubSpot API limits](https://developers.hubspot.com/docs/guides/apps/api-usage/usage-details#private-apps)

## Purpose
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
