### PR TITLE
List all associations of an object to other objects of a requested type

### DIFF
--- a/HubSpot.NET/Api/Associations/Dto/AssociationListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Associations/Dto/AssociationListHubSpotModel.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using HubSpot.NET.Core.Interfaces;
+using Newtonsoft.Json;
+
+namespace HubSpot.NET.Api.Associations.Dto;
+
+/// <summary>
+/// Models the associations of a HubSpot Object to other HubSpot Objects
+/// </summary>
+[DataContract]
+public class AssociationListHubSpotModel : IHubSpotModel
+{
+    [JsonProperty(PropertyName = "results")]
+    public List<Association> Associations { get; set; } = new ();
+
+    public class Association
+    {
+        [JsonProperty(PropertyName = "toObjectId")]
+        public long AssociatedObjectId { get; set; }
+        public List<AssociationType> AssociationTypes { get; set; } = new();
+    }
+
+    public class AssociationType
+    {
+        public string Category { get; set; } // HUBSPOT_DEFINED or USER_DEFINED
+        public long TypeId { get; set; }
+        public string Label { get; set; } // e.g. "Contact with Primary Company"
+    }
+
+
+    public bool IsNameValue => false;
+
+    public void ToHubSpotDataEntity(ref dynamic dataEntity) { }
+    
+    public void FromHubSpotDataEntity(dynamic hubspotData) { }
+    
+    public string RouteBasePath => "/crm/v4/objects/";
+}

--- a/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Api/Associations/HubSpotAssociationsApi.cs
@@ -1,3 +1,4 @@
+using HubSpot.NET.Api.Associations.Dto;
 using HubSpot.NET.Core.Interfaces;
 using RestSharp;
 
@@ -50,5 +51,19 @@ public class HubSpotAssociationsApi : IHubSpotAssociationsApi
         _client.Execute(associationPath, body, Method.PUT, convertToPropertiesSchema: false);
         
     }
-    
+
+    /// <summary>
+    /// Retrieves alls associations of a given object to the specified object type
+    /// </summary>
+    /// <param name="objectType">Object type id of the object whose associations you're retrieving (e.g. "0-2" for company)</param>
+    /// <param name="objectId">Object id of the object whose associations you're retrieving</param>
+    /// <param name="toObjectType">Object type id of the associations to retrieve (e.g. "0-1" for contact)</param>
+    /// <returns></returns>
+    public AssociationListHubSpotModel GetAssociations(string objectType, string objectId, string toObjectType)
+    {
+        var associationPath = $"/crm/v4/objects/{objectType}/{objectId}/associations/{toObjectType}";
+        var associations = _client.ExecuteList<AssociationListHubSpotModel>(associationPath, Method.GET, convertToPropertiesSchema: false);
+        
+        return associations;
+    }
 }

--- a/HubSpot.NET/Core/HubSpotApi.cs
+++ b/HubSpot.NET/Core/HubSpotApi.cs
@@ -16,9 +16,13 @@ using HubSpot.NET.Core.OAuth.Dto;
 
 namespace HubSpot.NET.Core
 {
+    /// <summary>
+    /// ObjectTypeIds (e.g. "0-1" = contact and "0-2" = company)
+    /// </summary>
     public class HubSpotObjectIds
     {
         public static readonly string Contact = "0-1";
+        public static readonly string Company = "0-2";
         public static readonly string Deal = "0-3";
     }
     

--- a/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotAssociationsApi.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using HubSpot.NET.Api.Associations.Dto;
+
 namespace HubSpot.NET.Core.Interfaces;
 
 public interface IHubSpotAssociationsApi
@@ -6,4 +9,6 @@ public interface IHubSpotAssociationsApi
 
     void AssociationToObjectByLabel(string objectType, string objectId, string toObjectType, string toObjectId,
         string associationCategory, int associationTypeId);
+
+    AssociationListHubSpotModel GetAssociations(string objectType, string objectId, string toObjectType);
 }


### PR DESCRIPTION
## Description
Creates a new method on the Associations API to list all associations of an object to other objects of a requested type

## Purpose
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
